### PR TITLE
Fix backend name for Stateful services

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -16,8 +16,8 @@
 [[projects]]
   name = "github.com/Masterminds/sprig"
   packages = ["."]
-  revision = "efda631a76d70875162cdc25ffa0d0164bf69758"
-  version = "v2.14.0"
+  revision = "b217b9c388de2cacde4354c536e520c52c055563"
+  version = "v2.14.1"
 
 [[projects]]
   name = "github.com/Sirupsen/logrus"
@@ -46,7 +46,7 @@
   branch = "master"
   name = "github.com/containous/traefik"
   packages = ["autogen/gentemplates","job","log","provider","safe","tls","tls/generate","types"]
-  revision = "0ca65f955da2d4f32dfb882b17fc0bce7a421f1c"
+  revision = "c66d9de759b4bdebf8e170539eac1bcdd1295894"
 
 [[projects]]
   name = "github.com/docker/libkv"
@@ -70,7 +70,7 @@
   branch = "master"
   name = "github.com/jjcollinge/servicefabric"
   packages = ["."]
-  revision = "93a44e59fc887cda489913c6fc5bda834989f3bd"
+  revision = "8026935326c842b71dee8e2329c1fda41a7a92f4"
 
 [[projects]]
   branch = "master"
@@ -94,19 +94,19 @@
   branch = "master"
   name = "golang.org/x/crypto"
   packages = ["pbkdf2","scrypt"]
-  revision = "b080dc9a8c480b08e698fb1219160d598526310f"
+  revision = "94eea52f7b742c7cbe0b03b22f0c4c8631ece122"
 
 [[projects]]
   branch = "master"
   name = "golang.org/x/net"
   packages = ["context"]
-  revision = "c7086645de248775cbf2373cf5ca4d2fa664b8c1"
+  revision = "a8b9294777976932365dabb6640cf1468d95c70f"
 
 [[projects]]
   branch = "master"
   name = "golang.org/x/sys"
   packages = ["unix"]
-  revision = "4ff8c001ce4cc464e644b922325097228fce14d8"
+  revision = "9167dbfd0f8e88b731dd88cbf73a270701a37bb4"
 
 [solve-meta]
   analyzer-name = "dep"

--- a/labels.go
+++ b/labels.go
@@ -1,23 +1,50 @@
 package servicefabric
 
-import "strings"
+import (
+	"github.com/containous/traefik/provider/label"
+)
 
-func hasServiceLabel(service ServiceItemExtended, key string) bool {
-	_, exists := service.Labels[key]
-	return exists
-}
-
-func getFuncBoolLabel(labelName string) func(service ServiceItemExtended) bool {
-	return func(service ServiceItemExtended) bool {
-		return getBoolLabel(service, labelName)
+// Must be replace by:
+// func hasFunc(labelName string) func(service ServiceItemExtended) bool {
+// 	return func(service ServiceItemExtended) bool {
+// 		return label.Has(service.Labels, labelName)
+// 	}
+// }
+// Deprecated
+func hasFunc() func(service ServiceItemExtended, labelName string) bool {
+	return func(service ServiceItemExtended, labelName string) bool {
+		return label.Has(service.Labels, labelName)
 	}
 }
 
-func getBoolLabel(service ServiceItemExtended, labelName string) bool {
-	value, exists := service.Labels[labelName]
-	return exists && strings.EqualFold(strings.TrimSpace(value), "true")
+func getFuncBoolLabel(labelName string, defaultValue bool) func(service ServiceItemExtended) bool {
+	return func(service ServiceItemExtended) bool {
+		return label.GetBoolValue(service.Labels, labelName, defaultValue)
+	}
 }
 
-func getServiceLabelValue(service ServiceItemExtended, key string) string {
-	return service.Labels[key]
+// Must be replace by:
+// func getFuncStringLabel(labelName string, defaultValue string) func(service ServiceItemExtended) string {
+// 	return func(service ServiceItemExtended) string {
+// 		return label.GetStringValue(service.Labels, labelName, defaultValue)
+// 	}
+// }
+// Deprecated
+func getFuncStringLabel(defaultValue string) func(service ServiceItemExtended, labelName string) string {
+	return func(service ServiceItemExtended, labelName string) string {
+		return label.GetStringValue(service.Labels, labelName, defaultValue)
+	}
+}
+
+// Must be replace by:
+// func getFuncStringLabel(labelName string, defaultValue string) func(service ServiceItemExtended) string {
+// 	return func(service ServiceItemExtended) string {
+// 		return label.GetStringValue(service.Labels, labelName, defaultValue)
+// 	}
+// }
+// Deprecated
+func getFuncStringLabelWithDefault() func(service ServiceItemExtended, labelName string, defaultValue string) string {
+	return func(service ServiceItemExtended, labelName string, defaultValue string) string {
+		return label.GetStringValue(service.Labels, labelName, defaultValue)
+	}
 }

--- a/servicefabric.go
+++ b/servicefabric.go
@@ -77,22 +77,21 @@ func (p *Provider) updateConfig(configurationChan chan<- types.ConfigMessage, po
 				templateObjects := struct {
 					Services []ServiceItemExtended
 				}{
-					services,
+					Services: services,
 				}
 
 				var sfFuncMap = template.FuncMap{
-					"isPrimary":                       isPrimary,
-					"getDefaultEndpoint":              p.getDefaultEndpoint,
-					"getNamedEndpoint":                p.getNamedEndpoint,
-					"getApplicationParameter":         p.getApplicationParameter,
-					"doesAppParamContain":             p.doesAppParamContain,
-					"hasServiceLabel":                 hasServiceLabel,
-					"getServiceLabelValue":            getServiceLabelValue,
-					"getServiceLabelValueWithDefault": getServiceLabelValueWithDefault,
-					"getServiceLabelsWithPrefix":      getServiceLabelsWithPrefix,
-					"getServicesWithLabelValueMap":    getServicesWithLabelValueMap,
-					"getServicesWithLabelValue":       getServicesWithLabelValue,
-					"isExposed":                       getFuncBoolLabel("expose"),
+					"isPrimary":                    isPrimary,
+					"getDefaultEndpoint":           p.getDefaultEndpoint,
+					"getNamedEndpoint":             p.getNamedEndpoint,
+					"getApplicationParameter":      p.getApplicationParameter,
+					"doesAppParamContain":          p.doesAppParamContain,
+					"hasLabel":                     hasFunc(),
+					"getLabelValue":                getFuncStringLabel(""),
+					"getLabelValueWithDefault":     getFuncStringLabelWithDefault(),
+					"getLabelsWithPrefix":          getLabelsWithPrefix,
+					"getServicesWithLabelValueMap": getServicesWithLabelValueMap,
+					"isExposed":                    getFuncBoolLabel("expose", false),
 				}
 
 				configuration, err := p.GetConfiguration(tmpl, sfFuncMap, templateObjects)
@@ -250,27 +249,7 @@ func getServicesWithLabelValueMap(services []ServiceItemExtended, key string) ma
 	return result
 }
 
-func getServicesWithLabelValue(services []ServiceItemExtended, key, expectedValue string) []ServiceItemExtended {
-	var srvWithLabel []ServiceItemExtended
-	for _, service := range services {
-		value, exists := service.Labels[key]
-		if exists && value == expectedValue {
-			srvWithLabel = append(srvWithLabel, service)
-		}
-	}
-	return srvWithLabel
-}
-
-func getServiceLabelValueWithDefault(service ServiceItemExtended, key, defaultValue string) string {
-	value, exists := service.Labels[key]
-
-	if !exists {
-		return defaultValue
-	}
-	return value
-}
-
-func getServiceLabelsWithPrefix(service ServiceItemExtended, prefix string) map[string]string {
+func getLabelsWithPrefix(service ServiceItemExtended, prefix string) map[string]string {
 	results := make(map[string]string)
 	for k, v := range service.Labels {
 		if strings.HasPrefix(k, prefix) {

--- a/servicefabric.go
+++ b/servicefabric.go
@@ -92,6 +92,7 @@ func (p *Provider) updateConfig(configurationChan chan<- types.ConfigMessage, po
 					"getLabelsWithPrefix":          getLabelsWithPrefix,
 					"getServicesWithLabelValueMap": getServicesWithLabelValueMap,
 					"isExposed":                    getFuncBoolLabel("expose", false),
+					"getBackendName":               getBackendName,
 				}
 
 				configuration, err := p.GetConfiguration(tmpl, sfFuncMap, templateObjects)
@@ -326,4 +327,8 @@ func getNamedEndpoint(endpointData string, endpointName string) (string, error) 
 		return "", errors.New("endpoint doesn't exist")
 	}
 	return endpoint, nil
+}
+
+func getBackendName(service ServiceItemExtended, partition PartitionItemExtended) string {
+	return provider.Normalize(service.Name + partition.PartitionInformation.ID)
 }

--- a/servicefabric_tmpl.go
+++ b/servicefabric_tmpl.go
@@ -10,7 +10,7 @@ const tmpl = `
           {{range $instance := $partition.Instances}}
             [backends."{{$aggName}}".servers."{{$service.ID}}-{{$instance.ID}}"]
             url = "{{getDefaultEndpoint $instance}}"
-            weight = {{getServiceLabelValueWithDefault $service "backend.group.weight" "1"}}
+            weight = {{getLabelValueWithDefault $service "backend.group.weight" "1"}}
           {{end}}
         {{end}}
       {{end}}
@@ -20,39 +20,39 @@ const tmpl = `
       {{if eq $partition.ServiceKind "Stateless"}}
       [backends."{{$service.Name}}"]
         [backends."{{$service.Name}}".LoadBalancer]
-        {{if hasServiceLabel $service "backend.loadbalancer.method"}}
-          method = "{{getServiceLabelValue $service "backend.loadbalancer.method" }}"
+        {{if hasLabel $service "backend.loadbalancer.method"}}
+          method = "{{getLabelValue $service "backend.loadbalancer.method" }}"
         {{else}}
           method = "drr"
         {{end}}
 
-        {{if hasServiceLabel $service "backend.healthcheck"}}
+        {{if hasLabel $service "backend.healthcheck"}}
           [backends."{{$service.Name}}".healthcheck]
-          path = "{{getServiceLabelValue $service "backend.healthcheck"}}"
-          interval = "{{getServiceLabelValueWithDefault $service "backend.healthcheck.interval" "10s"}}"
+          path = "{{getLabelValue $service "backend.healthcheck"}}"
+          interval = "{{getLabelValueWithDefault $service "backend.healthcheck.interval" "10s"}}"
         {{end}}
 
-        {{if hasServiceLabel $service "backend.loadbalancer.stickiness"}}
+        {{if hasLabel $service "backend.loadbalancer.stickiness"}}
           [backends."{{$service.Name}}".LoadBalancer.stickiness]
         {{end}}
 
-        {{if hasServiceLabel $service "backend.circuitbreaker"}}
+        {{if hasLabel $service "backend.circuitbreaker"}}
           [backends."{{$service.Name}}".circuitbreaker]
-          expression = "{{getServiceLabelValue $service "backend.circuitbreaker"}}"
+          expression = "{{getLabelValue $service "backend.circuitbreaker"}}"
         {{end}}
 
-        {{if hasServiceLabel $service "backend.maxconn.amount"}}
+        {{if hasLabel $service "backend.maxconn.amount"}}
           [backends."{{$service.Name}}".maxconn]
-          amount = {{getServiceLabelValue $service "backend.maxconn.amount"}}
-          {{if hasServiceLabel $service "backend.maxconn.extractorfunc"}}
-          extractorfunc = "{{getServiceLabelValue $service "backend.maxconn.extractorfunc"}}"
+          amount = {{getLabelValue $service "backend.maxconn.amount"}}
+          {{if hasLabel $service "backend.maxconn.extractorfunc"}}
+          extractorfunc = "{{getLabelValue $service "backend.maxconn.extractorfunc"}}"
           {{end}}
         {{end}}
 
         {{range $instance := $partition.Instances}}
           [backends."{{$service.Name}}".servers."{{$instance.ID}}"]
           url = "{{getDefaultEndpoint $instance}}"
-          weight = {{getServiceLabelValueWithDefault $service "backend.weight" "1"}}
+          weight = {{getLabelValueWithDefault $service "backend.weight" "1"}}
         {{end}}
       {{else if eq $partition.ServiceKind "Stateful"}}
         {{range $replica := $partition.Replicas}}
@@ -81,11 +81,11 @@ const tmpl = `
     [frontends."{{$groupName}}"]
     backend = "{{$groupName}}"
 
-    {{if hasServiceLabel $service "frontend.priority"}}
+    {{if hasLabel $service "frontend.priority"}}
     priority = 100
     {{end}}
 
-    {{range $key, $value := getServiceLabelsWithPrefix $service "frontend.rule"}}
+    {{range $key, $value := getLabelsWithPrefix $service "frontend.rule"}}
     [frontends."{{$groupName}}".routes."{{$key}}"]
     rule = "{{$value}}"
     {{end}}
@@ -97,27 +97,27 @@ const tmpl = `
     [frontends."{{$service.Name}}"]
     backend = "{{$service.Name}}"
 
-    {{if hasServiceLabel $service "frontend.passHostHeader"}}
-      passHostHeader = {{getServiceLabelValue $service "frontend.passHostHeader" }}
+    {{if hasLabel $service "frontend.passHostHeader"}}
+      passHostHeader = {{getLabelValue $service "frontend.passHostHeader" }}
     {{end}}
 
-    {{if hasServiceLabel $service "frontend.whitelistSourceRange"}}
-      whitelistSourceRange = {{getServiceLabelValue $service "frontend.whitelistSourceRange" }}
+    {{if hasLabel $service "frontend.whitelistSourceRange"}}
+      whitelistSourceRange = {{getLabelValue $service "frontend.whitelistSourceRange" }}
     {{end}}
 
-    {{if hasServiceLabel $service "frontend.priority"}}
-      priority = {{getServiceLabelValue $service "frontend.priority"}}
+    {{if hasLabel $service "frontend.priority"}}
+      priority = {{getLabelValue $service "frontend.priority"}}
     {{end}}
 
-    {{if hasServiceLabel $service "frontend.basicAuth"}}
-      basicAuth = {{getServiceLabelValue $service "frontend.basicAuth"}}
+    {{if hasLabel $service "frontend.basicAuth"}}
+      basicAuth = {{getLabelValue $service "frontend.basicAuth"}}
     {{end}}
 
-    {{if hasServiceLabel $service "frontend.entryPoints"}}
-      entryPoints = {{getServiceLabelValue $service "frontend.entryPoints"}}
+    {{if hasLabel $service "frontend.entryPoints"}}
+      entryPoints = {{getLabelValue $service "frontend.entryPoints"}}
     {{end}}
 
-    {{range $key, $value := getServiceLabelsWithPrefix $service "frontend.rule"}}
+    {{range $key, $value := getLabelsWithPrefix $service "frontend.rule"}}
     [frontends."{{$service.Name}}".routes."{{$key}}"]
     rule = "{{$value}}"
     {{end}}
@@ -126,11 +126,11 @@ const tmpl = `
       {{range $partition := $service.Partitions}}
         {{$partitionId := $partition.PartitionInformation.ID}}
 
-        {{if hasServiceLabel $service "frontend.rule"}}
+        {{if hasLabel $service "frontend.rule"}}
           [frontends."{{$service.Name}}/{{$partitionId}}"]
           backend = "{{$service.Name}}/{{$partitionId}}"
           [frontends."{{$service.Name}}/{{$partitionId}}".routes.default]
-          rule = {{getServiceLabelValue $service "frontend.rule.partition.$partitionId"}}
+          rule = {{getLabelValue $service "frontend.rule.partition.$partitionId"}}
 
       {{end}}
     {{end}}

--- a/servicefabric_tmpl.go
+++ b/servicefabric_tmpl.go
@@ -58,7 +58,7 @@ const tmpl = `
         {{range $replica := $partition.Replicas}}
           {{if isPrimary $replica}}
 
-            {{$backendName := (print $service.Name $partition.PartitionInformation.ID)}}
+            {{$backendName := getBackendName $service.Name $partition}}
             [backends."{{$backendName}}".servers."{{$replica.ID}}"]
             url = "{{getDefaultEndpoint $replica}}"
             weight = 1
@@ -124,16 +124,16 @@ const tmpl = `
 
     {{else if eq $service.ServiceKind "Stateful"}}
       {{range $partition := $service.Partitions}}
-        {{$partitionId := $partition.PartitionInformation.ID}}
-
         {{if hasLabel $service "frontend.rule"}}
+          {{$partitionId := $partition.PartitionInformation.ID}}
+
           [frontends."{{$service.Name}}/{{$partitionId}}"]
-          backend = "{{$service.Name}}/{{$partitionId}}"
+          backend = {{getBackendName $service.Name $partition}}
           [frontends."{{$service.Name}}/{{$partitionId}}".routes.default]
           rule = {{getLabelValue $service "frontend.rule.partition.$partitionId"}}
 
+        {{end}}
       {{end}}
-    {{end}}
   {{end}}
 {{end}}
 {{end}}


### PR DESCRIPTION
Fix backend name for Stateful services:
The name of the backend is `{{$backendName := (print $service.Name $partition.PartitionInformation.ID)}}` but the backend name in frontends is `backendName = {{$service.Name}}/{{$partitionId}}` (note the `/`)

Also:
- update Træfik version.
- Use new methods from Træfik for labels.
- remove unused methods
- rename functions in the template