### PR TITLE
fix: backend name for Stateful services.

### DIFF
--- a/labels.go
+++ b/labels.go
@@ -1,6 +1,8 @@
 package servicefabric
 
-import "strings"
+import (
+	"strings"
+)
 
 func hasServiceLabel(service ServiceItemExtended, key string) bool {
 	_, exists := service.Labels[key]

--- a/servicefabric.go
+++ b/servicefabric.go
@@ -93,6 +93,7 @@ func (p *Provider) updateConfig(configurationChan chan<- types.ConfigMessage, po
 					"getServicesWithLabelValueMap":    getServicesWithLabelValueMap,
 					"getServicesWithLabelValue":       getServicesWithLabelValue,
 					"isExposed":                       getFuncBoolLabel("expose"),
+					"getBackendName":                  getBackendName,
 				}
 
 				configuration, err := p.GetConfiguration(tmpl, sfFuncMap, templateObjects)
@@ -347,4 +348,8 @@ func getNamedEndpoint(endpointData string, endpointName string) (string, error) 
 		return "", errors.New("endpoint doesn't exist")
 	}
 	return endpoint, nil
+}
+
+func getBackendName(service ServiceItemExtended, partition PartitionItemExtended) string {
+	return provider.Normalize(service.Name + partition.PartitionInformation.ID)
 }

--- a/servicefabric_tmpl.go
+++ b/servicefabric_tmpl.go
@@ -58,7 +58,7 @@ const tmpl = `
         {{range $replica := $partition.Replicas}}
           {{if isPrimary $replica}}
 
-            {{$backendName := (print $service.Name $partition.PartitionInformation.ID)}}
+            {{$backendName := getBackendName $service.Name $partition}}
             [backends."{{$backendName}}".servers."{{$replica.ID}}"]
             url = "{{getDefaultEndpoint $replica}}"
             weight = 1
@@ -128,7 +128,7 @@ const tmpl = `
 
         {{if hasServiceLabel $service "frontend.rule"}}
           [frontends."{{$service.Name}}/{{$partitionId}}"]
-          backend = "{{$service.Name}}/{{$partitionId}}"
+          backend = "{{getBackendName $service.Name $partition}}"
           [frontends."{{$service.Name}}/{{$partitionId}}".routes.default]
           rule = {{getServiceLabelValue $service "frontend.rule.partition.$partitionId"}}
 


### PR DESCRIPTION
The name of the backend is:
- `{{$backendName := (print $service.Name $partition.PartitionInformation.ID)}}`

but the backend name in frontends is:
- `backendName = {{$service.Name}}/{{$partitionId}}` (note the `/`)