### PR TITLE
Update SF labels to use explicit methods and add missing labels

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .idea/
+.vscode/
 vendor/
 *.swp

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -69,7 +69,7 @@
 [[projects]]
   name = "github.com/jjcollinge/servicefabric"
   packages = ["."]
-  revision = "3daa0c1131aa90080d058ee2745fcd9050f0ab2c"
+  revision = "8eebe170fa1ba25d3dfb928b3f86a7313b13b9fe"
 
 [[projects]]
   branch = "master"
@@ -110,6 +110,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "0830acbf7741bf35b2e4f6b3bbe994c96792ecd0b020f171276149026413d70b"
+  inputs-digest = "80f3928471a7e1bc924cb3ed1dada3b44ce2c5a29f4e024aeb6ef336f8d67b79"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -67,10 +67,9 @@
   version = "0.2.4"
 
 [[projects]]
-  branch = "master"
   name = "github.com/jjcollinge/servicefabric"
   packages = ["."]
-  revision = "8026935326c842b71dee8e2329c1fda41a7a92f4"
+  revision = "3daa0c1131aa90080d058ee2745fcd9050f0ab2c"
 
 [[projects]]
   branch = "master"
@@ -111,6 +110,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "08bb135bc0df562ae59ace5c6d190d9cf3da44adf97a5b92e0930a7e81c21f96"
+  inputs-digest = "0830acbf7741bf35b2e4f6b3bbe994c96792ecd0b020f171276149026413d70b"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -34,7 +34,7 @@
   branch = "master"
   name = "github.com/cenk/backoff"
   packages = ["."]
-  revision = "309aa717adbf351e92864cbedf9cca0b769a4b5a"
+  revision = "2ea60e5f094469f9e65adb9cd103795b73ae743e"
 
 [[projects]]
   name = "github.com/containous/flaeg"
@@ -46,7 +46,7 @@
   branch = "master"
   name = "github.com/containous/traefik"
   packages = ["autogen/gentemplates","job","log","provider","provider/label","safe","tls","tls/generate","types"]
-  revision = "c66d9de759b4bdebf8e170539eac1bcdd1295894"
+  revision = "06d528a2bdc5398a4552f78d2304d9c390b7ccf6"
 
 [[projects]]
   name = "github.com/docker/libkv"
@@ -58,7 +58,7 @@
   branch = "master"
   name = "github.com/huandu/xstrings"
   packages = ["."]
-  revision = "d6590c0c31d16526217fa60fbd2067f7afcd78c5"
+  revision = "37469d0c81a7910b49d64a0d308ded4823e90937"
 
 [[projects]]
   name = "github.com/imdario/mergo"
@@ -94,19 +94,19 @@
   branch = "master"
   name = "golang.org/x/crypto"
   packages = ["pbkdf2","scrypt"]
-  revision = "94eea52f7b742c7cbe0b03b22f0c4c8631ece122"
+  revision = "0fcca4842a8d74bfddc2c96a073bd2a4d2a7a2e8"
 
 [[projects]]
   branch = "master"
   name = "golang.org/x/net"
   packages = ["context"]
-  revision = "a8b9294777976932365dabb6640cf1468d95c70f"
+  revision = "d866cfc389cec985d6fda2859936a575a55a3ab6"
 
 [[projects]]
   branch = "master"
   name = "golang.org/x/sys"
   packages = ["unix"]
-  revision = "9167dbfd0f8e88b731dd88cbf73a270701a37bb4"
+  revision = "28a7276518d399b9634904daad79e18b44d481bc"
 
 [solve-meta]
   analyzer-name = "dep"

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -45,7 +45,7 @@
 [[projects]]
   branch = "master"
   name = "github.com/containous/traefik"
-  packages = ["autogen/gentemplates","job","log","provider","safe","tls","tls/generate","types"]
+  packages = ["autogen/gentemplates","job","log","provider","provider/label","safe","tls","tls/generate","types"]
   revision = "c66d9de759b4bdebf8e170539eac1bcdd1295894"
 
 [[projects]]
@@ -111,6 +111,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "416c19433395ee38c69ccff5eddf90cababcf7336231d740a9847a937dcbb3b7"
+  inputs-digest = "08bb135bc0df562ae59ace5c6d190d9cf3da44adf97a5b92e0930a7e81c21f96"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -2,10 +2,10 @@
 
 
 [[projects]]
+  branch = "master"
   name = "github.com/BurntSushi/toml"
   packages = ["."]
-  revision = "b26d9c308763d68093482582cea63d69be07a0f0"
-  version = "v0.3.0"
+  revision = "a368813c5e648fee92e5f6c30e3944ff9d5e8895"
 
 [[projects]]
   name = "github.com/Masterminds/semver"
@@ -20,9 +20,10 @@
   version = "v2.14.1"
 
 [[projects]]
-  name = "github.com/Sirupsen/logrus"
-  packages = ["."]
-  revision = "10f801ebc38b33738c9d17d50860f484a0988ff5"
+  branch = "master"
+  name = "github.com/abronan/valkeyrie"
+  packages = ["store"]
+  revision = "063d875e3c5fd734fa2aa12fac83829f62acfc70"
 
 [[projects]]
   name = "github.com/aokoli/goutils"
@@ -38,33 +39,58 @@
 
 [[projects]]
   name = "github.com/containous/flaeg"
+  packages = [
+    ".",
+    "parse"
+  ]
+  revision = "b4c2f060875361c070ed2bc300c5929b82f5fa2e"
+  version = "v1.1.2"
+
+[[projects]]
+  branch = "master"
+  name = "github.com/containous/mux"
   packages = ["."]
-  revision = "4b6f66624dce34a226f080b414c4705ea8731bc5"
-  version = "v1.0.0"
+  revision = "06ccd3e75091eb659b1d720cda0e16bc7057954c"
 
 [[projects]]
   branch = "master"
   name = "github.com/containous/traefik"
-  packages = ["autogen/gentemplates","job","log","provider","provider/label","safe","tls","tls/generate","types"]
-  revision = "06d528a2bdc5398a4552f78d2304d9c390b7ccf6"
+  packages = [
+    "autogen/gentemplates",
+    "job",
+    "log",
+    "provider",
+    "provider/label",
+    "safe",
+    "tls",
+    "tls/generate",
+    "types"
+  ]
+  revision = "329c576f445aa5c7b310f4bc465e704b67c7c2b1"
 
 [[projects]]
-  name = "github.com/docker/libkv"
-  packages = ["store"]
-  revision = "aabc039ad04deb721e234f99cd1b4aa28ac71a40"
-  version = "v0.2.1"
+  name = "github.com/davecgh/go-spew"
+  packages = ["spew"]
+  revision = "346938d642f2ec3594ed81d874461961cd0faa76"
+  version = "v1.1.0"
 
 [[projects]]
-  branch = "master"
+  name = "github.com/gorilla/context"
+  packages = ["."]
+  revision = "1ea25387ff6f684839d82767c1733ff4d4d15d0a"
+  version = "v1.1"
+
+[[projects]]
   name = "github.com/huandu/xstrings"
   packages = ["."]
-  revision = "37469d0c81a7910b49d64a0d308ded4823e90937"
+  revision = "2bf18b218c51864a87384c06996e40ff9dcff8e1"
+  version = "v1.0.0"
 
 [[projects]]
   name = "github.com/imdario/mergo"
   packages = ["."]
-  revision = "7fe0c75c13abdee74b09fcacef5ea1c6bba6a874"
-  version = "0.2.4"
+  revision = "163f41321a19dd09362d4c63cc2489db2015f1f4"
+  version = "0.3.2"
 
 [[projects]]
   name = "github.com/jjcollinge/servicefabric"
@@ -78,38 +104,66 @@
   revision = "45c278ab3607870051a2ea9040bb85fcb8557481"
 
 [[projects]]
+  name = "github.com/pmezard/go-difflib"
+  packages = ["difflib"]
+  revision = "792786c7400a136282c1664665ae0a8db921c6c2"
+  version = "v1.0.0"
+
+[[projects]]
+  branch = "master"
   name = "github.com/ryanuber/go-glob"
   packages = ["."]
-  revision = "572520ed46dbddaed19ea3d9541bdd0494163693"
-  version = "v0.1"
+  revision = "256dc444b735e061061cf46c809487313d5b0065"
 
 [[projects]]
   name = "github.com/satori/go.uuid"
   packages = ["."]
-  revision = "879c5887cd475cd7864858769793b2ceb0d44feb"
-  version = "v1.1.0"
+  revision = "f58768cc1a7a7e77a3bd49e98cdd21419399b6a3"
+  version = "v1.2.0"
+
+[[projects]]
+  name = "github.com/sirupsen/logrus"
+  packages = ["."]
+  revision = "c155da19408a8799da419ed3eeb0cb5db0ad5dbc"
+  version = "v1.0.5"
+
+[[projects]]
+  name = "github.com/stretchr/testify"
+  packages = [
+    "assert",
+    "require"
+  ]
+  revision = "12b6f73e6084dad08a7c6e575284b177ecafbc71"
+  version = "v1.2.1"
 
 [[projects]]
   branch = "master"
   name = "golang.org/x/crypto"
-  packages = ["pbkdf2","scrypt"]
-  revision = "0fcca4842a8d74bfddc2c96a073bd2a4d2a7a2e8"
+  packages = [
+    "pbkdf2",
+    "scrypt",
+    "ssh/terminal"
+  ]
+  revision = "80db560fac1fb3e6ac81dbc7f8ae4c061f5257bd"
 
 [[projects]]
   branch = "master"
   name = "golang.org/x/net"
   packages = ["context"]
-  revision = "d866cfc389cec985d6fda2859936a575a55a3ab6"
+  revision = "6078986fec03a1dcc236c34816c71b0e05018fda"
 
 [[projects]]
   branch = "master"
   name = "golang.org/x/sys"
-  packages = ["unix"]
-  revision = "28a7276518d399b9634904daad79e18b44d481bc"
+  packages = [
+    "unix",
+    "windows"
+  ]
+  revision = "641605214e7dab930817f68e2fef560efbb033e5"
 
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "80f3928471a7e1bc924cb3ed1dada3b44ce2c5a29f4e024aeb6ef336f8d67b79"
+  inputs-digest = "439e87370bde2964292e65861a25a490fecd3b52b366357861b4d9e65dd34098"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -1,8 +1,8 @@
 ignored = ["github.com/containous/traefik/autogen/genstatic"]
 
 [[constraint]]
-  branch = "master"
   name = "github.com/jjcollinge/servicefabric"
+  revision = "3daa0c1131aa90080d058ee2745fcd9050f0ab2c"
 
 [[constraint]]
   branch = "master"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -2,7 +2,7 @@ ignored = ["github.com/containous/traefik/autogen/genstatic"]
 
 [[constraint]]
   name = "github.com/jjcollinge/servicefabric"
-  revision = "3daa0c1131aa90080d058ee2745fcd9050f0ab2c"
+  revision = "8eebe170fa1ba25d3dfb928b3f86a7313b13b9fe"
 
 [[constraint]]
   branch = "master"

--- a/client_mock_test.go
+++ b/client_mock_test.go
@@ -40,7 +40,7 @@ func (c *clientMock) GetInstances(appName, serviceName, partitionName string) (*
 
 func (c *clientMock) GetServiceExtensionMap(service *sf.ServiceItem, app *sf.ApplicationItem, extensionKey string) (map[string]string, error) {
 	if extensionKey != traefikServiceFabricExtensionKey {
-		return nil, fmt.Errorf("Extension key not expected value have: %v expect: %v", extensionKey, traefikServiceFabricExtensionKey)
+		return nil, fmt.Errorf("extension key not expected value have: %s expect: %s", extensionKey, traefikServiceFabricExtensionKey)
 	}
 	return c.getServiceExtensionMapResult, nil
 }

--- a/client_mock_test.go
+++ b/client_mock_test.go
@@ -1,16 +1,21 @@
 package servicefabric
 
 import (
+	"fmt"
+
 	sf "github.com/jjcollinge/servicefabric"
 )
 
 type clientMock struct {
-	applications *sf.ApplicationItemsPage
-	services     *sf.ServiceItemsPage
-	partitions   *sf.PartitionItemsPage
-	replicas     *sf.ReplicaItemsPage
-	instances    *sf.InstanceItemsPage
-	labels       map[string]string
+	applications                 *sf.ApplicationItemsPage
+	services                     *sf.ServiceItemsPage
+	partitions                   *sf.PartitionItemsPage
+	replicas                     *sf.ReplicaItemsPage
+	instances                    *sf.InstanceItemsPage
+	getServicelabelsResult       map[string]string
+	expectedPropertyName         string
+	getServiceExtensionMapResult map[string]string
+	getPropertiesResult          map[string]string
 }
 
 func (c *clientMock) GetApplications() (*sf.ApplicationItemsPage, error) {
@@ -33,10 +38,21 @@ func (c *clientMock) GetInstances(appName, serviceName, partitionName string) (*
 	return c.instances, nil
 }
 
-func (c *clientMock) GetServiceExtension(appType, applicationVersion, serviceTypeName, extensionKey string, response interface{}) error {
-	return nil
+func (c *clientMock) GetServiceExtensionMap(service *sf.ServiceItem, app *sf.ApplicationItem, extensionKey string) (map[string]string, error) {
+	if extensionKey != traefikServiceFabricExtensionKey {
+		return nil, fmt.Errorf("Extension key not expected value have: %v expect: %v", extensionKey, traefikServiceFabricExtensionKey)
+	}
+	return c.getServiceExtensionMapResult, nil
 }
 
 func (c *clientMock) GetServiceLabels(service *sf.ServiceItem, app *sf.ApplicationItem, prefix string) (map[string]string, error) {
-	return c.labels, nil
+	return c.getServicelabelsResult, nil
+}
+
+// Note this is dumb mock the `exists`
+func (c *clientMock) GetProperties(name string) (bool, map[string]string, error) {
+	if c.expectedPropertyName == name {
+		return true, c.getPropertiesResult, nil
+	}
+	return false, nil, nil
 }

--- a/config.go
+++ b/config.go
@@ -1,0 +1,62 @@
+package servicefabric
+
+import (
+	"text/template"
+
+	"github.com/containous/traefik/provider/label"
+	"github.com/containous/traefik/types"
+)
+
+func (p *Provider) buildConfiguration(sfClient sfClient) (*types.Configuration, error) {
+	var sfFuncMap = template.FuncMap{
+
+		// Services
+		"getServices":                getServices,
+		"hasLabel":                   hasService,
+		"getLabelValue":              getServiceStringLabel,
+		"getLabelsWithPrefix":        getServiceLabelsWithPrefix,
+		"isPrimary":                  isPrimary,
+		"isEnabled":                  getFuncBoolLabel(label.TraefikEnable, false),
+		"getBackendName":             getBackendName,
+		"getDefaultEndpoint":         getDefaultEndpoint,
+		"getNamedEndpoint":           getNamedEndpoint,           // FIXME unused
+		"getApplicationParameter":    getApplicationParameter,    // FIXME unused
+		"doesAppParamContain":        doesAppParamContain,        // FIXME unused
+		"filterServicesByLabelValue": filterServicesByLabelValue, // FIXME unused
+
+		// Frontend Functions
+		"getPriority":             getFuncServiceStringLabel(label.TraefikFrontendPriority, label.DefaultFrontendPriority),
+		"hasRequestHeaders":       hasFuncService(label.TraefikFrontendRequestHeaders),
+		"getRequestHeaders":       getFuncServiceMapLabel(label.TraefikFrontendRequestHeaders),
+		"hasFrameDenyHeaders":     hasFuncService(label.TraefikFrontendFrameDeny),
+		"getFrameDenyHeaders":     getFuncBoolLabel(label.TraefikFrontendFrameDeny, false),
+		"getPassHostHeader":       getFuncServiceStringLabel(label.TraefikFrontendPassHostHeader, label.DefaultPassHostHeader),
+		"getPassTLSCert":          getFuncBoolLabel(label.TraefikFrontendPassTLSCert, false),
+		"hasEntryPoints":          hasFuncService(label.TraefikFrontendEntryPoints),
+		"getEntryPoints":          getFuncServiceSliceStringLabel(label.TraefikFrontendEntryPoints),
+		"getBasicAuth":            getFuncServiceSliceStringLabel(label.TraefikFrontendAuthBasic),
+		"getWhitelistSourceRange": getFuncServiceSliceStringLabel(label.TraefikFrontendWhitelistSourceRange),
+		"hasRedirect":             hasRedirect,
+		"getRedirectEntryPoint":   getFuncServiceStringLabel(label.TraefikFrontendRedirectEntryPoint, label.DefaultFrontendRedirectEntryPoint),
+		"getRedirectRegex":        getFuncServiceStringLabel(label.TraefikFrontendRedirectRegex, ""),
+		"getRedirectReplacement":  getFuncServiceStringLabel(label.TraefikFrontendRedirectReplacement, ""),
+	}
+
+	services, err := getClusterServices(sfClient)
+	if err != nil {
+		return nil, err
+	}
+
+	templateObjects := struct {
+		Services []ServiceItemExtended
+	}{
+		Services: services,
+	}
+
+	return p.GetConfiguration(tmpl, sfFuncMap, templateObjects)
+}
+
+func hasRedirect(service ServiceItemExtended) bool {
+	return label.Has(service.Labels, label.TraefikFrontendRedirectEntryPoint) ||
+		label.Has(service.Labels, label.TraefikFrontendRedirectReplacement) && label.Has(service.Labels, label.TraefikFrontendRedirectRegex)
+}

--- a/config.go
+++ b/config.go
@@ -2,6 +2,7 @@ package servicefabric
 
 import (
 	"math"
+	"strings"
 	"text/template"
 
 	"github.com/containous/traefik/provider/label"
@@ -44,11 +45,11 @@ func (p *Provider) buildConfiguration(sfClient sfClient) (*types.Configuration, 
 		"getStickinessCookieName":     getFuncServiceStringLabel(label.TraefikBackendLoadBalancerStickinessCookieName, label.DefaultBackendLoadbalancerStickinessCookieName),
 
 		// Frontend Functions
-		"getPriority":             getFuncServiceStringLabel(label.TraefikFrontendPriority, label.DefaultFrontendPriority),
-		"hasRequestHeaders":       hasFuncService(label.TraefikFrontendRequestHeaders),
-		"getRequestHeaders":       getFuncServiceMapLabel(label.TraefikFrontendRequestHeaders),
-		"hasFrameDenyHeaders":     hasFuncService(label.TraefikFrontendFrameDeny),
-		"getFrameDenyHeaders":     getFuncBoolLabel(label.TraefikFrontendFrameDeny, false),
+		"getPriority": getFuncServiceStringLabel(label.TraefikFrontendPriority, label.DefaultFrontendPriority),
+		// "hasRequestHeaders":       hasFuncService(label.TraefikFrontendRequestHeaders),
+		// "getRequestHeaders":       getFuncServiceMapLabel(label.TraefikFrontendRequestHeaders),
+		// "hasFrameDenyHeaders":     hasFuncService(label.TraefikFrontendFrameDeny),
+		// "getFrameDenyHeaders":     getFuncBoolLabel(label.TraefikFrontendFrameDeny, false),
 		"getPassHostHeader":       getFuncServiceStringLabel(label.TraefikFrontendPassHostHeader, label.DefaultPassHostHeader),
 		"getPassTLSCert":          getFuncBoolLabel(label.TraefikFrontendPassTLSCert, false),
 		"hasEntryPoints":          hasFuncService(label.TraefikFrontendEntryPoints),
@@ -61,6 +62,49 @@ func (p *Provider) buildConfiguration(sfClient sfClient) (*types.Configuration, 
 		"getRedirectRegex":        getFuncServiceStringLabel(label.TraefikFrontendRedirectRegex, ""),
 		"getRedirectReplacement":  getFuncServiceStringLabel(label.TraefikFrontendRedirectReplacement, ""),
 		"getFrontendRules":        getFuncServiceLabelWithPrefix(label.TraefikFrontendRule),
+
+		// Headers
+		"hasHeaders":                        hasHeaders,
+		"hasRequestHeaders":                 hasFuncService(label.TraefikFrontendRequestHeaders),
+		"getRequestHeaders":                 getFuncMapLabel(label.TraefikFrontendRequestHeaders),
+		"hasResponseHeaders":                hasFuncService(label.TraefikFrontendResponseHeaders),
+		"getResponseHeaders":                getFuncMapLabel(label.TraefikFrontendResponseHeaders),
+		"hasAllowedHostsHeaders":            hasFuncService(label.TraefikFrontendAllowedHosts),
+		"getAllowedHostsHeaders":            getFuncServiceSliceStringLabel(label.TraefikFrontendAllowedHosts),
+		"hasHostsProxyHeaders":              hasFuncService(label.TraefikFrontendHostsProxyHeaders),
+		"getHostsProxyHeaders":              getFuncServiceSliceStringLabel(label.TraefikFrontendHostsProxyHeaders),
+		"hasSSLRedirectHeaders":             hasFuncService(label.TraefikFrontendSSLRedirect),
+		"getSSLRedirectHeaders":             getFuncBoolLabel(label.TraefikFrontendSSLRedirect, false),
+		"hasSSLTemporaryRedirectHeaders":    hasFuncService(label.TraefikFrontendSSLTemporaryRedirect),
+		"getSSLTemporaryRedirectHeaders":    getFuncBoolLabel(label.TraefikFrontendSSLTemporaryRedirect, false),
+		"hasSSLHostHeaders":                 hasFuncService(label.TraefikFrontendSSLHost),
+		"getSSLHostHeaders":                 getFuncServiceSliceStringLabel(label.TraefikFrontendSSLHost),
+		"hasSSLProxyHeaders":                hasFuncService(label.TraefikFrontendSSLProxyHeaders),
+		"getSSLProxyHeaders":                getFuncMapLabel(label.TraefikFrontendSSLProxyHeaders),
+		"hasSTSSecondsHeaders":              hasFuncService(label.TraefikFrontendSTSSeconds),
+		"getSTSSecondsHeaders":              getFuncInt64Label(label.TraefikFrontendSTSSeconds, 0),
+		"hasSTSIncludeSubdomainsHeaders":    hasFuncService(label.TraefikFrontendSTSIncludeSubdomains),
+		"getSTSIncludeSubdomainsHeaders":    getFuncBoolLabel(label.TraefikFrontendSTSIncludeSubdomains, false),
+		"hasSTSPreloadHeaders":              hasFuncService(label.TraefikFrontendSTSPreload),
+		"getSTSPreloadHeaders":              getFuncBoolLabel(label.TraefikFrontendSTSPreload, false),
+		"hasForceSTSHeaderHeaders":          hasFuncService(label.TraefikFrontendForceSTSHeader),
+		"getForceSTSHeaderHeaders":          getFuncBoolLabel(label.TraefikFrontendForceSTSHeader, false),
+		"hasFrameDenyHeaders":               hasFuncService(label.TraefikFrontendFrameDeny),
+		"getFrameDenyHeaders":               getFuncBoolLabel(label.TraefikFrontendFrameDeny, false),
+		"hasCustomFrameOptionsValueHeaders": hasFuncService(label.TraefikFrontendCustomFrameOptionsValue),
+		"getCustomFrameOptionsValueHeaders": getFuncServiceSliceStringLabel(label.TraefikFrontendCustomFrameOptionsValue),
+		"hasContentTypeNosniffHeaders":      hasFuncService(label.TraefikFrontendContentTypeNosniff),
+		"getContentTypeNosniffHeaders":      getFuncBoolLabel(label.TraefikFrontendContentTypeNosniff, false),
+		"hasBrowserXSSFilterHeaders":        hasFuncService(label.TraefikFrontendBrowserXSSFilter),
+		"getBrowserXSSFilterHeaders":        getFuncBoolLabel(label.TraefikFrontendBrowserXSSFilter, false),
+		"hasContentSecurityPolicyHeaders":   hasFuncService(label.TraefikFrontendContentSecurityPolicy),
+		"getContentSecurityPolicyHeaders":   getFuncServiceSliceStringLabel(label.TraefikFrontendContentSecurityPolicy),
+		"hasPublicKeyHeaders":               hasFuncService(label.TraefikFrontendPublicKey),
+		"getPublicKeyHeaders":               getFuncServiceSliceStringLabel(label.TraefikFrontendPublicKey),
+		"hasReferrerPolicyHeaders":          hasFuncService(label.TraefikFrontendReferrerPolicy),
+		"getReferrerPolicyHeaders":          getFuncServiceSliceStringLabel(label.TraefikFrontendReferrerPolicy),
+		"hasIsDevelopmentHeaders":           hasFuncService(label.TraefikFrontendIsDevelopment),
+		"getIsDevelopmentHeaders":           getFuncBoolLabel(label.TraefikFrontendIsDevelopment, false),
 
 		// SF Service Grouping
 		"getGroupedServices": getFuncServicesGroupedByLabel(TraefikSFGroupName),
@@ -98,4 +142,13 @@ func hasMaxConnLabels(service ServiceItemExtended) bool {
 	mca := label.Has(service.Labels, label.TraefikBackendMaxConnAmount)
 	mcef := label.Has(service.Labels, label.TraefikBackendMaxConnExtractorFunc)
 	return mca && mcef
+}
+
+func hasHeaders(service ServiceItemExtended) bool {
+	for key := range service.Labels {
+		if strings.HasPrefix(key, label.TraefikFrontendHeaders) {
+			return true
+		}
+	}
+	return false
 }

--- a/config.go
+++ b/config.go
@@ -1,6 +1,7 @@
 package servicefabric
 
 import (
+	"math"
 	"text/template"
 
 	"github.com/containous/traefik/provider/label"
@@ -24,6 +25,24 @@ func (p *Provider) buildConfiguration(sfClient sfClient) (*types.Configuration, 
 		"doesAppParamContain":        doesAppParamContain,        // FIXME unused
 		"filterServicesByLabelValue": filterServicesByLabelValue, // FIXME unused
 
+		// Backend functions
+		"getWeight":                   getFuncServiceStringLabel(label.TraefikWeight, label.DefaultWeight),
+		"getProtocol":                 getFuncServiceStringLabel(label.TraefikProtocol, label.DefaultProtocol),
+		"hasHealthCheckLabels":        hasFuncService(label.TraefikBackendHealthCheckPath),
+		"getHealthCheckPath":          getFuncServiceStringLabel(label.TraefikBackendHealthCheckPath, ""),
+		"getHealthCheckPort":          getFuncServiceStringLabel(label.TraefikBackendHealthCheckPort, "0"),
+		"getHealthCheckInterval":      getFuncServiceStringLabel(label.TraefikBackendHealthCheckInterval, ""),
+		"hasCircuitBreakerLabel":      hasFuncService(label.TraefikBackendCircuitBreakerExpression),
+		"getCircuitBreakerExpression": getFuncServiceStringLabel(label.TraefikBackendCircuitBreakerExpression, label.DefaultCircuitBreakerExpression),
+		"hasLoadBalancerLabel":        hasLoadBalancerLabel,
+		"getLoadBalancerMethod":       getFuncServiceStringLabel(label.TraefikBackendLoadBalancerMethod, label.DefaultBackendLoadBalancerMethod),
+		"hasMaxConnLabels":            hasMaxConnLabels,
+		"getMaxConnAmount":            getFuncServiceStringLabel(label.TraefikBackendMaxConnAmount, string(math.MaxInt64)),
+		"getMaxConnExtractorFunc":     getFuncServiceStringLabel(label.TraefikBackendMaxConnExtractorFunc, label.DefaultBackendMaxconnExtractorFunc),
+		"getSticky":                   getFuncBoolLabel(label.TraefikBackendLoadBalancerSticky, false),
+		"hasStickinessLabel":          hasFuncService(label.TraefikBackendLoadBalancerStickiness),
+		"getStickinessCookieName":     getFuncServiceStringLabel(label.TraefikBackendLoadBalancerStickinessCookieName, label.DefaultBackendLoadbalancerStickinessCookieName),
+
 		// Frontend Functions
 		"getPriority":             getFuncServiceStringLabel(label.TraefikFrontendPriority, label.DefaultFrontendPriority),
 		"hasRequestHeaders":       hasFuncService(label.TraefikFrontendRequestHeaders),
@@ -34,12 +53,18 @@ func (p *Provider) buildConfiguration(sfClient sfClient) (*types.Configuration, 
 		"getPassTLSCert":          getFuncBoolLabel(label.TraefikFrontendPassTLSCert, false),
 		"hasEntryPoints":          hasFuncService(label.TraefikFrontendEntryPoints),
 		"getEntryPoints":          getFuncServiceSliceStringLabel(label.TraefikFrontendEntryPoints),
+		"hasBasicAuth":            hasFuncService(label.TraefikFrontendAuthBasic),
 		"getBasicAuth":            getFuncServiceSliceStringLabel(label.TraefikFrontendAuthBasic),
 		"getWhitelistSourceRange": getFuncServiceSliceStringLabel(label.TraefikFrontendWhitelistSourceRange),
 		"hasRedirect":             hasRedirect,
 		"getRedirectEntryPoint":   getFuncServiceStringLabel(label.TraefikFrontendRedirectEntryPoint, label.DefaultFrontendRedirectEntryPoint),
 		"getRedirectRegex":        getFuncServiceStringLabel(label.TraefikFrontendRedirectRegex, ""),
 		"getRedirectReplacement":  getFuncServiceStringLabel(label.TraefikFrontendRedirectReplacement, ""),
+		"getFrontendRules":        getFuncServiceLabelWithPrefix(label.TraefikFrontendRule),
+
+		// SF Service Grouping
+		"getGroupedServices": getFuncServicesGroupedByLabel(TraefikSFGroupName),
+		"getGroupedWeight":   getFuncServiceStringLabel(TraefikSFGroupWeight, "1"),
 	}
 
 	services, err := getClusterServices(sfClient)
@@ -59,4 +84,18 @@ func (p *Provider) buildConfiguration(sfClient sfClient) (*types.Configuration, 
 func hasRedirect(service ServiceItemExtended) bool {
 	return label.Has(service.Labels, label.TraefikFrontendRedirectEntryPoint) ||
 		label.Has(service.Labels, label.TraefikFrontendRedirectReplacement) && label.Has(service.Labels, label.TraefikFrontendRedirectRegex)
+}
+
+func hasLoadBalancerLabel(service ServiceItemExtended) bool {
+	method := label.Has(service.Labels, label.TraefikBackendLoadBalancerMethod)
+	sticky := label.Has(service.Labels, label.TraefikBackendLoadBalancerSticky)
+	stickiness := label.Has(service.Labels, label.TraefikBackendLoadBalancerStickiness)
+	cookieName := label.Has(service.Labels, label.TraefikBackendLoadBalancerStickinessCookieName)
+	return method || sticky || stickiness || cookieName
+}
+
+func hasMaxConnLabels(service ServiceItemExtended) bool {
+	mca := label.Has(service.Labels, label.TraefikBackendMaxConnAmount)
+	mcef := label.Has(service.Labels, label.TraefikBackendMaxConnExtractorFunc)
+	return mca && mcef
 }

--- a/labels.go
+++ b/labels.go
@@ -16,17 +16,17 @@ func getServiceStringLabel(service ServiceItemExtended, labelName string, defaul
 	return label.GetStringValue(service.Labels, labelName, defaultValue)
 }
 
-// Example how I will name funcs as I add them
-// func getFuncServiceStringLabel(labelName string, defaultValue string) func(service ServiceItemExtended) string {
-// 	return func(service ServiceItemExtended) string {
-// 		return label.GetStringValue(service.Labels, labelName, defaultValue)
-// 	}
-// }
-// func getFuncServiceSliceStringLabel(labelName string) func(service ServiceItemExtended) []string {
-// 	return func(service ServiceItemExtended) []string {
-// 		return label.GetSliceStringValue(service.Labels, labelName)
-// 	}
-// }
+func getFuncServiceStringLabel(labelName string, defaultValue string) func(service ServiceItemExtended) string {
+	return func(service ServiceItemExtended) string {
+		return label.GetStringValue(service.Labels, labelName, defaultValue)
+	}
+}
+
+func getFuncServiceSliceStringLabel(labelName string) func(service ServiceItemExtended) []string {
+	return func(service ServiceItemExtended) []string {
+		return label.GetSliceStringValue(service.Labels, labelName)
+	}
+}
 
 func hasService(service ServiceItemExtended, labelName string) bool {
 	return label.Has(service.Labels, labelName)

--- a/labels.go
+++ b/labels.go
@@ -12,6 +12,18 @@ const (
 	TraefikSFGroupWeight = "Traefik.SF.GroupWeight"
 )
 
+func getFuncInt64Label(labelName string, defaultValue int64) func(service ServiceItemExtended) int64 {
+	return func(service ServiceItemExtended) int64 {
+		return label.GetInt64Value(service.Labels, labelName, defaultValue)
+	}
+}
+
+func getFuncMapLabel(labelName string) func(service ServiceItemExtended) map[string]string {
+	return func(service ServiceItemExtended) map[string]string {
+		return label.GetMapValue(service.Labels, labelName)
+	}
+}
+
 func getFuncBoolLabel(labelName string, defaultValue bool) func(service ServiceItemExtended) bool {
 	return func(service ServiceItemExtended) bool {
 		return label.GetBoolValue(service.Labels, labelName, defaultValue)
@@ -41,12 +53,6 @@ func hasService(service ServiceItemExtended, labelName string) bool {
 func hasFuncService(labelName string) func(service ServiceItemExtended) bool {
 	return func(service ServiceItemExtended) bool {
 		return label.Has(service.Labels, labelName)
-	}
-}
-
-func getFuncServiceMapLabel(labelName string) func(service ServiceItemExtended) map[string]string {
-	return func(service ServiceItemExtended) map[string]string {
-		return label.GetMapValue(service.Labels, labelName)
 	}
 }
 

--- a/labels.go
+++ b/labels.go
@@ -6,6 +6,12 @@ import (
 	"github.com/containous/traefik/provider/label"
 )
 
+// SF Specific Traefik Labels
+const (
+	TraefikSFGroupName   = "Traefik.SF.GroupName"
+	TraefikSFGroupWeight = "Traefik.SF.GroupWeight"
+)
+
 func getFuncBoolLabel(labelName string, defaultValue bool) func(service ServiceItemExtended) bool {
 	return func(service ServiceItemExtended) bool {
 		return label.GetBoolValue(service.Labels, labelName, defaultValue)
@@ -41,6 +47,18 @@ func hasFuncService(labelName string) func(service ServiceItemExtended) bool {
 func getFuncServiceMapLabel(labelName string) func(service ServiceItemExtended) map[string]string {
 	return func(service ServiceItemExtended) map[string]string {
 		return label.GetMapValue(service.Labels, labelName)
+	}
+}
+
+func getFuncServiceLabelWithPrefix(labelName string) func(service ServiceItemExtended) map[string]string {
+	return func(service ServiceItemExtended) map[string]string {
+		return getServiceLabelsWithPrefix(service, labelName)
+	}
+}
+
+func getFuncServicesGroupedByLabel(labelName string) func(services []ServiceItemExtended) map[string][]ServiceItemExtended {
+	return func(services []ServiceItemExtended) map[string][]ServiceItemExtended {
+		return getServices(services, labelName)
 	}
 }
 

--- a/labels.go
+++ b/labels.go
@@ -12,12 +12,36 @@ func getFuncBoolLabel(labelName string, defaultValue bool) func(service ServiceI
 	}
 }
 
-func getFuncServiceStringLabel(service ServiceItemExtended, labelName string, defaultValue string) string {
+func getServiceStringLabel(service ServiceItemExtended, labelName string, defaultValue string) string {
 	return label.GetStringValue(service.Labels, labelName, defaultValue)
 }
 
-func hasFuncService(service ServiceItemExtended, labelName string) bool {
+// Example how I will name funcs as I add them
+// func getFuncServiceStringLabel(labelName string, defaultValue string) func(service ServiceItemExtended) string {
+// 	return func(service ServiceItemExtended) string {
+// 		return label.GetStringValue(service.Labels, labelName, defaultValue)
+// 	}
+// }
+// func getFuncServiceSliceStringLabel(labelName string) func(service ServiceItemExtended) []string {
+// 	return func(service ServiceItemExtended) []string {
+// 		return label.GetSliceStringValue(service.Labels, labelName)
+// 	}
+// }
+
+func hasService(service ServiceItemExtended, labelName string) bool {
 	return label.Has(service.Labels, labelName)
+}
+
+func hasFuncService(labelName string) func(service ServiceItemExtended) bool {
+	return func(service ServiceItemExtended) bool {
+		return label.Has(service.Labels, labelName)
+	}
+}
+
+func getFuncServiceMapLabel(labelName string) func(service ServiceItemExtended) map[string]string {
+	return func(service ServiceItemExtended) map[string]string {
+		return label.GetMapValue(service.Labels, labelName)
+	}
 }
 
 func getServiceLabelsWithPrefix(service ServiceItemExtended, prefix string) map[string]string {

--- a/labels.go
+++ b/labels.go
@@ -8,8 +8,8 @@ import (
 
 // SF Specific Traefik Labels
 const (
-	TraefikSFGroupName   = "Traefik.SF.GroupName"
-	TraefikSFGroupWeight = "Traefik.SF.GroupWeight"
+	TraefikSFGroupName   = "traefik.sf.groupname"
+	TraefikSFGroupWeight = "traefik.sf.groupweight"
 )
 
 func getFuncInt64Label(labelName string, defaultValue int64) func(service ServiceItemExtended) int64 {

--- a/servicefabric.go
+++ b/servicefabric.go
@@ -16,7 +16,7 @@ import (
 
 var _ provider.Provider = (*Provider)(nil)
 
-const traefikServiceFabricExtensionKey = "Traeifk"
+const traefikServiceFabricExtensionKey = "Traefik"
 
 // Provider holds for configuration for the provider
 type Provider struct {

--- a/servicefabric.go
+++ b/servicefabric.go
@@ -190,7 +190,7 @@ func hasHTTPEndpoint(instanceData *sf.ReplicaItemBase) bool {
 func getLabels(sfClient sfClient, service *sf.ServiceItem, app *sf.ApplicationItem) (map[string]string, error) {
 	labels, err := sfClient.GetServiceExtensionMap(service, app, traefikServiceFabricExtensionKey)
 	if err != nil {
-		log.Errorf("Error retreiving serviceExtensionMap: %v", err)
+		log.Errorf("Error retrieving serviceExtensionMap: %v", err)
 		return nil, err
 	}
 

--- a/servicefabric.go
+++ b/servicefabric.go
@@ -18,8 +18,6 @@ import (
 
 var _ provider.Provider = (*Provider)(nil)
 
-const traefikLabelPrefix = "traefik"
-
 // Provider holds for configuration for the provider
 type Provider struct {
 	provider.BaseProvider `mapstructure:",squash"`

--- a/servicefabric.go
+++ b/servicefabric.go
@@ -12,6 +12,7 @@ import (
 	"github.com/containous/traefik/job"
 	"github.com/containous/traefik/log"
 	"github.com/containous/traefik/provider"
+	"github.com/containous/traefik/provider/label"
 	"github.com/containous/traefik/safe"
 	"github.com/containous/traefik/types"
 	sf "github.com/jjcollinge/servicefabric"
@@ -96,17 +97,23 @@ func (p *Provider) updateConfig(configurationChan chan<- types.ConfigMessage, po
 func (p *Provider) buildConfiguration(sfClient sfClient) (*types.Configuration, error) {
 	var sfFuncMap = template.FuncMap{
 		"getServices":                getServices,
-		"hasLabel":                   hasFuncService,
-		"getLabelValue":              getFuncServiceStringLabel,
+		"hasLabel":                   hasService,
+		"getLabelValue":              getServiceStringLabel,
 		"getLabelsWithPrefix":        getServiceLabelsWithPrefix,
 		"isPrimary":                  isPrimary,
-		"isExposed":                  getFuncBoolLabel("expose", false),
+		"isEnabled":                  getFuncBoolLabel(label.SuffixEnable, false),
 		"getBackendName":             getBackendName,
 		"getDefaultEndpoint":         getDefaultEndpoint,
 		"getNamedEndpoint":           getNamedEndpoint,           // FIXME unused
 		"getApplicationParameter":    getApplicationParameter,    // FIXME unused
 		"doesAppParamContain":        doesAppParamContain,        // FIXME unused
 		"filterServicesByLabelValue": filterServicesByLabelValue, // FIXME unused
+
+		"getPassTLSCert":      getFuncBoolLabel(label.SuffixFrontendPassTLSCert, false),
+		"hasRequestHeaders":   hasFuncService(label.SuffixFrontendRequestHeaders),
+		"getRequestHeaders":   getFuncServiceMapLabel(label.SuffixFrontendRequestHeaders),
+		"hasFrameDenyHeaders": hasFuncService(label.SuffixFrontendHeadersFrameDeny),
+		"getFrameDenyHeaders": getFuncBoolLabel(label.SuffixFrontendHeadersFrameDeny, false),
 	}
 
 	services, err := getClusterServices(sfClient)

--- a/servicefabric_config.go
+++ b/servicefabric_config.go
@@ -34,80 +34,24 @@ func (p *Provider) buildConfiguration(sfClient sfClient) (*types.Configuration, 
 		"filterServicesByLabelValue": filterServicesByLabelValue, // FIXME unused
 
 		// Backend functions
-		"getWeight":                   getFuncServiceStringLabel(label.TraefikWeight, label.DefaultWeight),
-		"getProtocol":                 getFuncServiceStringLabel(label.TraefikProtocol, label.DefaultProtocol),
-		"hasHealthCheckLabels":        hasFuncService(label.TraefikBackendHealthCheckPath),
-		"getHealthCheckPath":          getFuncServiceStringLabel(label.TraefikBackendHealthCheckPath, ""),
-		"getHealthCheckPort":          getFuncServiceStringLabel(label.TraefikBackendHealthCheckPort, "0"),
-		"getHealthCheckInterval":      getFuncServiceStringLabel(label.TraefikBackendHealthCheckInterval, ""),
-		"hasCircuitBreakerLabel":      hasFuncService(label.TraefikBackendCircuitBreakerExpression),
-		"getCircuitBreakerExpression": getFuncServiceStringLabel(label.TraefikBackendCircuitBreakerExpression, label.DefaultCircuitBreakerExpression),
-		"hasLoadBalancerLabel":        hasLoadBalancerLabel,
-		"getLoadBalancerMethod":       getFuncServiceStringLabel(label.TraefikBackendLoadBalancerMethod, label.DefaultBackendLoadBalancerMethod),
-		"hasMaxConnLabels":            hasMaxConnLabels,
-		"getMaxConnAmount":            getFuncServiceStringLabel(label.TraefikBackendMaxConnAmount, string(math.MaxInt64)),
-		"getMaxConnExtractorFunc":     getFuncServiceStringLabel(label.TraefikBackendMaxConnExtractorFunc, label.DefaultBackendMaxconnExtractorFunc),
-		"getSticky":                   getFuncBoolLabel(label.TraefikBackendLoadBalancerSticky, false),
-		"hasStickinessLabel":          hasFuncService(label.TraefikBackendLoadBalancerStickiness),
-		"getStickinessCookieName":     getFuncServiceStringLabel(label.TraefikBackendLoadBalancerStickinessCookieName, label.DefaultBackendLoadbalancerStickinessCookieName),
+		"getWeight":         getFuncServiceStringLabel(label.TraefikWeight, label.DefaultWeight),
+		"getProtocol":       getFuncServiceStringLabel(label.TraefikProtocol, label.DefaultProtocol),
+		"getMaxConn":        getMaxConn,
+		"getHealthCheck":    getHealthCheck,
+		"getCircuitBreaker": getCircuitBreaker,
+		"getLoadBalancer":   getLoadBalancer,
 
 		// Frontend Functions
 		"getPriority":             getFuncServiceStringLabel(label.TraefikFrontendPriority, label.DefaultFrontendPriority),
 		"getPassHostHeader":       getFuncServiceStringLabel(label.TraefikFrontendPassHostHeader, label.DefaultPassHostHeader),
 		"getPassTLSCert":          getFuncBoolLabel(label.TraefikFrontendPassTLSCert, false),
-		"hasEntryPoints":          hasFuncService(label.TraefikFrontendEntryPoints),
 		"getEntryPoints":          getFuncServiceSliceStringLabel(label.TraefikFrontendEntryPoints),
-		"hasBasicAuth":            hasFuncService(label.TraefikFrontendAuthBasic),
 		"getBasicAuth":            getFuncServiceSliceStringLabel(label.TraefikFrontendAuthBasic),
 		"getWhitelistSourceRange": getFuncServiceSliceStringLabel(label.TraefikFrontendWhitelistSourceRange),
-		"hasRedirect":             hasRedirect,
-		"getRedirectEntryPoint":   getFuncServiceStringLabel(label.TraefikFrontendRedirectEntryPoint, label.DefaultFrontendRedirectEntryPoint),
-		"getRedirectRegex":        getFuncServiceStringLabel(label.TraefikFrontendRedirectRegex, ""),
-		"getRedirectReplacement":  getFuncServiceStringLabel(label.TraefikFrontendRedirectReplacement, ""),
 		"getFrontendRules":        getFuncServiceLabelWithPrefix(label.TraefikFrontendRule),
 
-		// Headers
-		"hasHeaders":                        hasHeaders,
-		"hasRequestHeaders":                 hasFuncService(label.TraefikFrontendRequestHeaders),
-		"getRequestHeaders":                 getFuncMapLabel(label.TraefikFrontendRequestHeaders),
-		"hasResponseHeaders":                hasFuncService(label.TraefikFrontendResponseHeaders),
-		"getResponseHeaders":                getFuncMapLabel(label.TraefikFrontendResponseHeaders),
-		"hasAllowedHostsHeaders":            hasFuncService(label.TraefikFrontendAllowedHosts),
-		"getAllowedHostsHeaders":            getFuncServiceSliceStringLabel(label.TraefikFrontendAllowedHosts),
-		"hasHostsProxyHeaders":              hasFuncService(label.TraefikFrontendHostsProxyHeaders),
-		"getHostsProxyHeaders":              getFuncServiceSliceStringLabel(label.TraefikFrontendHostsProxyHeaders),
-		"hasSSLRedirectHeaders":             hasFuncService(label.TraefikFrontendSSLRedirect),
-		"getSSLRedirectHeaders":             getFuncBoolLabel(label.TraefikFrontendSSLRedirect, false),
-		"hasSSLTemporaryRedirectHeaders":    hasFuncService(label.TraefikFrontendSSLTemporaryRedirect),
-		"getSSLTemporaryRedirectHeaders":    getFuncBoolLabel(label.TraefikFrontendSSLTemporaryRedirect, false),
-		"hasSSLHostHeaders":                 hasFuncService(label.TraefikFrontendSSLHost),
-		"getSSLHostHeaders":                 getFuncServiceSliceStringLabel(label.TraefikFrontendSSLHost),
-		"hasSSLProxyHeaders":                hasFuncService(label.TraefikFrontendSSLProxyHeaders),
-		"getSSLProxyHeaders":                getFuncMapLabel(label.TraefikFrontendSSLProxyHeaders),
-		"hasSTSSecondsHeaders":              hasFuncService(label.TraefikFrontendSTSSeconds),
-		"getSTSSecondsHeaders":              getFuncInt64Label(label.TraefikFrontendSTSSeconds, 0),
-		"hasSTSIncludeSubdomainsHeaders":    hasFuncService(label.TraefikFrontendSTSIncludeSubdomains),
-		"getSTSIncludeSubdomainsHeaders":    getFuncBoolLabel(label.TraefikFrontendSTSIncludeSubdomains, false),
-		"hasSTSPreloadHeaders":              hasFuncService(label.TraefikFrontendSTSPreload),
-		"getSTSPreloadHeaders":              getFuncBoolLabel(label.TraefikFrontendSTSPreload, false),
-		"hasForceSTSHeaderHeaders":          hasFuncService(label.TraefikFrontendForceSTSHeader),
-		"getForceSTSHeaderHeaders":          getFuncBoolLabel(label.TraefikFrontendForceSTSHeader, false),
-		"hasFrameDenyHeaders":               hasFuncService(label.TraefikFrontendFrameDeny),
-		"getFrameDenyHeaders":               getFuncBoolLabel(label.TraefikFrontendFrameDeny, false),
-		"hasCustomFrameOptionsValueHeaders": hasFuncService(label.TraefikFrontendCustomFrameOptionsValue),
-		"getCustomFrameOptionsValueHeaders": getFuncServiceSliceStringLabel(label.TraefikFrontendCustomFrameOptionsValue),
-		"hasContentTypeNosniffHeaders":      hasFuncService(label.TraefikFrontendContentTypeNosniff),
-		"getContentTypeNosniffHeaders":      getFuncBoolLabel(label.TraefikFrontendContentTypeNosniff, false),
-		"hasBrowserXSSFilterHeaders":        hasFuncService(label.TraefikFrontendBrowserXSSFilter),
-		"getBrowserXSSFilterHeaders":        getFuncBoolLabel(label.TraefikFrontendBrowserXSSFilter, false),
-		"hasContentSecurityPolicyHeaders":   hasFuncService(label.TraefikFrontendContentSecurityPolicy),
-		"getContentSecurityPolicyHeaders":   getFuncServiceSliceStringLabel(label.TraefikFrontendContentSecurityPolicy),
-		"hasPublicKeyHeaders":               hasFuncService(label.TraefikFrontendPublicKey),
-		"getPublicKeyHeaders":               getFuncServiceSliceStringLabel(label.TraefikFrontendPublicKey),
-		"hasReferrerPolicyHeaders":          hasFuncService(label.TraefikFrontendReferrerPolicy),
-		"getReferrerPolicyHeaders":          getFuncServiceSliceStringLabel(label.TraefikFrontendReferrerPolicy),
-		"hasIsDevelopmentHeaders":           hasFuncService(label.TraefikFrontendIsDevelopment),
-		"getIsDevelopmentHeaders":           getFuncBoolLabel(label.TraefikFrontendIsDevelopment, false),
+		"getHeaders":  getHeaders,
+		"getRedirect": getRedirect,
 
 		// SF Service Grouping
 		"getGroupedServices": getFuncServicesGroupedByLabel(traefikSFGroupName),
@@ -134,34 +78,6 @@ func isStateful(service ServiceItemExtended) bool {
 
 func isStateless(service ServiceItemExtended) bool {
 	return service.ServiceKind == "Stateless"
-}
-
-func hasRedirect(service ServiceItemExtended) bool {
-	return label.Has(service.Labels, label.TraefikFrontendRedirectEntryPoint) ||
-		label.Has(service.Labels, label.TraefikFrontendRedirectReplacement) && label.Has(service.Labels, label.TraefikFrontendRedirectRegex)
-}
-
-func hasLoadBalancerLabel(service ServiceItemExtended) bool {
-	method := label.Has(service.Labels, label.TraefikBackendLoadBalancerMethod)
-	sticky := label.Has(service.Labels, label.TraefikBackendLoadBalancerSticky)
-	stickiness := label.Has(service.Labels, label.TraefikBackendLoadBalancerStickiness)
-	cookieName := label.Has(service.Labels, label.TraefikBackendLoadBalancerStickinessCookieName)
-	return method || sticky || stickiness || cookieName
-}
-
-func hasMaxConnLabels(service ServiceItemExtended) bool {
-	mca := label.Has(service.Labels, label.TraefikBackendMaxConnAmount)
-	mcef := label.Has(service.Labels, label.TraefikBackendMaxConnExtractorFunc)
-	return mca && mcef
-}
-
-func hasHeaders(service ServiceItemExtended) bool {
-	for key := range service.Labels {
-		if strings.HasPrefix(key, label.TraefikFrontendHeaders) {
-			return true
-		}
-	}
-	return false
 }
 
 func getBackendName(service ServiceItemExtended, partition PartitionItemExtended) string {
@@ -279,4 +195,127 @@ func decodeEndpointData(endpointData string) (map[string]string, error) {
 	}
 
 	return endpoints, nil
+}
+
+func getHeaders(service ServiceItemExtended) *types.Headers {
+	headers := &types.Headers{
+		CustomRequestHeaders:    label.GetMapValue(service.Labels, label.TraefikFrontendRequestHeaders),
+		CustomResponseHeaders:   label.GetMapValue(service.Labels, label.TraefikFrontendResponseHeaders),
+		SSLProxyHeaders:         label.GetMapValue(service.Labels, label.TraefikFrontendSSLProxyHeaders),
+		AllowedHosts:            label.GetSliceStringValue(service.Labels, label.TraefikFrontendAllowedHosts),
+		HostsProxyHeaders:       label.GetSliceStringValue(service.Labels, label.TraefikFrontendHostsProxyHeaders),
+		STSSeconds:              label.GetInt64Value(service.Labels, label.TraefikFrontendSTSSeconds, 0),
+		SSLRedirect:             label.GetBoolValue(service.Labels, label.TraefikFrontendSSLRedirect, false),
+		SSLTemporaryRedirect:    label.GetBoolValue(service.Labels, label.TraefikFrontendSSLTemporaryRedirect, false),
+		STSIncludeSubdomains:    label.GetBoolValue(service.Labels, label.TraefikFrontendSTSIncludeSubdomains, false),
+		STSPreload:              label.GetBoolValue(service.Labels, label.TraefikFrontendSTSPreload, false),
+		ForceSTSHeader:          label.GetBoolValue(service.Labels, label.TraefikFrontendForceSTSHeader, false),
+		FrameDeny:               label.GetBoolValue(service.Labels, label.TraefikFrontendFrameDeny, false),
+		ContentTypeNosniff:      label.GetBoolValue(service.Labels, label.TraefikFrontendContentTypeNosniff, false),
+		BrowserXSSFilter:        label.GetBoolValue(service.Labels, label.TraefikFrontendBrowserXSSFilter, false),
+		IsDevelopment:           label.GetBoolValue(service.Labels, label.TraefikFrontendIsDevelopment, false),
+		SSLHost:                 label.GetStringValue(service.Labels, label.TraefikFrontendSSLHost, ""),
+		CustomFrameOptionsValue: label.GetStringValue(service.Labels, label.TraefikFrontendCustomFrameOptionsValue, ""),
+		ContentSecurityPolicy:   label.GetStringValue(service.Labels, label.TraefikFrontendContentSecurityPolicy, ""),
+		PublicKey:               label.GetStringValue(service.Labels, label.TraefikFrontendPublicKey, ""),
+		ReferrerPolicy:          label.GetStringValue(service.Labels, label.TraefikFrontendReferrerPolicy, ""),
+		CustomBrowserXSSValue:   label.GetStringValue(service.Labels, label.TraefikFrontendCustomBrowserXSSValue, ""),
+	}
+
+	if !headers.HasSecureHeadersDefined() && !headers.HasCustomHeadersDefined() {
+		return nil
+	}
+
+	return headers
+}
+
+func getRedirect(service ServiceItemExtended) *types.Redirect {
+	permanent := label.GetBoolValue(service.Labels, label.TraefikFrontendRedirectPermanent, false)
+
+	if label.Has(service.Labels, label.TraefikFrontendRedirectEntryPoint) {
+		return &types.Redirect{
+			EntryPoint: label.GetStringValue(service.Labels, label.TraefikFrontendRedirectEntryPoint, ""),
+			Permanent:  permanent,
+		}
+	}
+
+	if label.Has(service.Labels, label.TraefikFrontendRedirectRegex) &&
+		label.Has(service.Labels, label.TraefikFrontendRedirectReplacement) {
+		return &types.Redirect{
+			Regex:       label.GetStringValue(service.Labels, label.TraefikFrontendRedirectRegex, ""),
+			Replacement: label.GetStringValue(service.Labels, label.TraefikFrontendRedirectReplacement, ""),
+			Permanent:   permanent,
+		}
+	}
+
+	return nil
+}
+
+func getMaxConn(service ServiceItemExtended) *types.MaxConn {
+	amount := label.GetInt64Value(service.Labels, label.TraefikBackendMaxConnAmount, math.MinInt64)
+	extractorFunc := label.GetStringValue(service.Labels, label.TraefikBackendMaxConnExtractorFunc, label.DefaultBackendMaxconnExtractorFunc)
+
+	if amount == math.MinInt64 || len(extractorFunc) == 0 {
+		return nil
+	}
+
+	return &types.MaxConn{
+		Amount:        amount,
+		ExtractorFunc: extractorFunc,
+	}
+}
+
+func getHealthCheck(service ServiceItemExtended) *types.HealthCheck {
+	path := label.GetStringValue(service.Labels, label.TraefikBackendHealthCheckPath, "")
+	if len(path) == 0 {
+		return nil
+	}
+
+	port := label.GetIntValue(service.Labels, label.TraefikBackendHealthCheckPort, label.DefaultBackendHealthCheckPort)
+	interval := label.GetStringValue(service.Labels, label.TraefikBackendHealthCheckInterval, "")
+
+	return &types.HealthCheck{
+		Path:     path,
+		Port:     port,
+		Interval: interval,
+	}
+}
+
+func getCircuitBreaker(service ServiceItemExtended) *types.CircuitBreaker {
+	circuitBreaker := label.GetStringValue(service.Labels, label.TraefikBackendCircuitBreakerExpression, "")
+	if len(circuitBreaker) == 0 {
+		return nil
+	}
+	return &types.CircuitBreaker{Expression: circuitBreaker}
+}
+
+func getLoadBalancer(service ServiceItemExtended) *types.LoadBalancer {
+	if !label.HasPrefix(service.Labels, label.TraefikBackendLoadBalancer) {
+		return nil
+	}
+
+	method := label.GetStringValue(service.Labels, label.TraefikBackendLoadBalancerMethod, label.DefaultBackendLoadBalancerMethod)
+
+	lb := &types.LoadBalancer{
+		Method: method,
+		Sticky: getSticky(service),
+	}
+
+	if label.GetBoolValue(service.Labels, label.TraefikBackendLoadBalancerStickiness, false) {
+		cookieName := label.GetStringValue(service.Labels, label.TraefikBackendLoadBalancerStickinessCookieName, label.DefaultBackendLoadbalancerStickinessCookieName)
+		lb.Stickiness = &types.Stickiness{CookieName: cookieName}
+	}
+
+	return lb
+}
+
+// TODO: Deprecated
+// replaced by Stickiness
+// Deprecated
+func getSticky(service ServiceItemExtended) bool {
+	if label.Has(service.Labels, label.TraefikBackendLoadBalancerSticky) {
+		log.Warnf("Deprecated configuration found: %s. Please use %s.", label.TraefikBackendLoadBalancerSticky, label.TraefikBackendLoadBalancerStickiness)
+	}
+
+	return label.GetBoolValue(service.Labels, label.TraefikBackendLoadBalancerSticky, false)
 }

--- a/servicefabric_config.go
+++ b/servicefabric_config.go
@@ -110,8 +110,8 @@ func (p *Provider) buildConfiguration(sfClient sfClient) (*types.Configuration, 
 		"getIsDevelopmentHeaders":           getFuncBoolLabel(label.TraefikFrontendIsDevelopment, false),
 
 		// SF Service Grouping
-		"getGroupedServices": getFuncServicesGroupedByLabel(TraefikSFGroupName),
-		"getGroupedWeight":   getFuncServiceStringLabel(TraefikSFGroupWeight, "1"),
+		"getGroupedServices": getFuncServicesGroupedByLabel(traefikSFGroupName),
+		"getGroupedWeight":   getFuncServiceStringLabel(traefikSFGroupWeight, "1"),
 	}
 
 	services, err := getClusterServices(sfClient)

--- a/servicefabric_labelfuncs.go
+++ b/servicefabric_labelfuncs.go
@@ -8,9 +8,10 @@ import (
 
 // SF Specific Traefik Labels
 const (
-	TraefikSFGroupName            = "traefik.servicefabric.groupname"
-	TraefikSFGroupWeight          = "traefik.servicefabric.groupweight"
-	TraefikSFEnableLabelOverrides = "traefik.servicefabric.enablelabeloverrides"
+	traefikSFGroupName                   = "traefik.servicefabric.groupname"
+	traefikSFGroupWeight                 = "traefik.servicefabric.groupweight"
+	traefikSFEnableLabelOverrides        = "traefik.servicefabric.enablelabeloverrides"
+	traefikSFEnableLabelOverridesDefault = true
 )
 
 func getFuncInt64Label(labelName string, defaultValue int64) func(service ServiceItemExtended) int64 {

--- a/servicefabric_labelfuncs.go
+++ b/servicefabric_labelfuncs.go
@@ -8,8 +8,9 @@ import (
 
 // SF Specific Traefik Labels
 const (
-	TraefikSFGroupName   = "traefik.sf.groupname"
-	TraefikSFGroupWeight = "traefik.sf.groupweight"
+	TraefikSFGroupName            = "traefik.servicefabric.groupname"
+	TraefikSFGroupWeight          = "traefik.servicefabric.groupweight"
+	TraefikSFEnableLabelOverrides = "traefik.servicefabric.enablelabeloverrides"
 )
 
 func getFuncInt64Label(labelName string, defaultValue int64) func(service ServiceItemExtended) int64 {

--- a/servicefabric_labelfuncs.go
+++ b/servicefabric_labelfuncs.go
@@ -14,18 +14,6 @@ const (
 	traefikSFEnableLabelOverridesDefault = true
 )
 
-func getFuncInt64Label(labelName string, defaultValue int64) func(service ServiceItemExtended) int64 {
-	return func(service ServiceItemExtended) int64 {
-		return label.GetInt64Value(service.Labels, labelName, defaultValue)
-	}
-}
-
-func getFuncMapLabel(labelName string) func(service ServiceItemExtended) map[string]string {
-	return func(service ServiceItemExtended) map[string]string {
-		return label.GetMapValue(service.Labels, labelName)
-	}
-}
-
 func getFuncBoolLabel(labelName string, defaultValue bool) func(service ServiceItemExtended) bool {
 	return func(service ServiceItemExtended) bool {
 		return label.GetBoolValue(service.Labels, labelName, defaultValue)
@@ -50,12 +38,6 @@ func getFuncServiceSliceStringLabel(labelName string) func(service ServiceItemEx
 
 func hasService(service ServiceItemExtended, labelName string) bool {
 	return label.Has(service.Labels, labelName)
-}
-
-func hasFuncService(labelName string) func(service ServiceItemExtended) bool {
-	return func(service ServiceItemExtended) bool {
-		return label.Has(service.Labels, labelName)
-	}
 }
 
 func getFuncServiceLabelWithPrefix(labelName string) func(service ServiceItemExtended) map[string]string {

--- a/servicefabric_test.go
+++ b/servicefabric_test.go
@@ -216,6 +216,7 @@ func TestServicesPresentInConfig(t *testing.T) {
 	}
 }
 
+// nolint: gocyclo
 func TestFrontendLabelConfig(t *testing.T) {
 	testCases := []struct {
 		desc     string
@@ -369,6 +370,7 @@ func TestFrontendLabelConfig(t *testing.T) {
 	}
 }
 
+// nolint: gocyclo
 func TestBackendLabelConfig(t *testing.T) {
 	testCases := []struct {
 		desc     string

--- a/servicefabric_test.go
+++ b/servicefabric_test.go
@@ -893,6 +893,54 @@ func TestIsHealthy(t *testing.T) {
 	}
 }
 
+func TestIsStateX(t *testing.T) {
+	testCases := []struct {
+		desc              string
+		serviceItem       ServiceItemExtended
+		expectedStateless bool
+		expectedStateful  bool
+	}{
+		{
+			desc: "With Stateful service",
+			serviceItem: ServiceItemExtended{
+				ServiceItem: sf.ServiceItem{
+					ServiceKind: "Stateful",
+				},
+			},
+			expectedStateless: false,
+			expectedStateful:  true,
+		},
+		{
+			desc: "With Stateless service",
+			serviceItem: ServiceItemExtended{
+				ServiceItem: sf.ServiceItem{
+					ServiceKind: "Stateless",
+				},
+			},
+			expectedStateless: true,
+			expectedStateful:  false,
+		},
+	}
+
+	for _, test := range testCases {
+		test := test
+		t.Run(test.desc, func(t *testing.T) {
+			t.Parallel()
+
+			isStatefulResult := isStateful(test.serviceItem)
+			isStatelessResult := isStateless(test.serviceItem)
+
+			if isStatefulResult != test.expectedStateful {
+				t.Errorf("Failed isStateful. Got %v, expected %v", isStatefulResult, test.expectedStateful)
+			}
+
+			if isStatelessResult != test.expectedStateless {
+				t.Errorf("Failed isStateless. Got %v, expected %v", isStatelessResult, test.expectedStateless)
+			}
+		})
+	}
+}
+
 func TestGetReplicaDefaultEndpoint(t *testing.T) {
 	testCases := []struct {
 		desc             string

--- a/servicefabric_test.go
+++ b/servicefabric_test.go
@@ -297,6 +297,97 @@ func TestFrontendLabelConfig(t *testing.T) {
 			validate: func(f types.Frontend) bool { return !f.PassTLSCert },
 		},
 		{
+			desc: "Has rule set",
+			labels: map[string]string{
+				label.TraefikEnable:                    "true",
+				label.TraefikFrontendRule + ".default": "Path: /",
+			},
+			validate: func(f types.Frontend) bool {
+				return len(f.Routes) == 1 && f.Routes[label.TraefikFrontendRule+".default"].Rule == "Path: /"
+			},
+		},
+		{
+			desc: "Has SSLRedirectHeaders set",
+			labels: map[string]string{
+				label.TraefikEnable:              "true",
+				label.TraefikFrontendSSLRedirect: "true",
+			},
+			validate: func(f types.Frontend) bool {
+				return f.Headers.SSLRedirect
+			},
+		},
+		{
+			desc: "Has Temporary SSLRedirectHeaders set",
+			labels: map[string]string{
+				label.TraefikEnable:                       "true",
+				label.TraefikFrontendSSLTemporaryRedirect: "true",
+			},
+			validate: func(f types.Frontend) bool {
+				return f.Headers.SSLTemporaryRedirect
+			},
+		},
+		//Todo: Is this behaviour correct "bob.bob.com" => "[bob.bob.com]"?
+		{
+			desc: "Has SSLHostHeaders set",
+			labels: map[string]string{
+				label.TraefikEnable:          "true",
+				label.TraefikFrontendSSLHost: "bob.bob.com",
+			},
+			validate: func(f types.Frontend) bool {
+				return f.Headers.SSLHost == "[bob.bob.com]"
+			},
+		},
+		{
+			desc: "Has STSSecondsHeaders set",
+			labels: map[string]string{
+				label.TraefikEnable:             "true",
+				label.TraefikFrontendSTSSeconds: "1337",
+			},
+			validate: func(f types.Frontend) bool {
+				return f.Headers.STSSeconds == 1337
+			},
+		},
+		{
+			desc: "Has STSIncludeSubdomainsHeaders set",
+			labels: map[string]string{
+				label.TraefikEnable:                       "true",
+				label.TraefikFrontendSTSIncludeSubdomains: "true",
+			},
+			validate: func(f types.Frontend) bool {
+				return f.Headers.STSIncludeSubdomains
+			},
+		},
+		{
+			desc: "Has STSPreloadHeaders set",
+			labels: map[string]string{
+				label.TraefikEnable:             "true",
+				label.TraefikFrontendSTSPreload: "true",
+			},
+			validate: func(f types.Frontend) bool {
+				return f.Headers.STSPreload
+			},
+		},
+		{
+			desc: "Has hasForceSTSHeaderHeaders set",
+			labels: map[string]string{
+				label.TraefikEnable:                 "true",
+				label.TraefikFrontendForceSTSHeader: "true",
+			},
+			validate: func(f types.Frontend) bool {
+				return f.Headers.ForceSTSHeader
+			},
+		},
+		{
+			desc: "Has hasForceSTSHeaderHeaders set",
+			labels: map[string]string{
+				label.TraefikEnable:                 "true",
+				label.TraefikFrontendForceSTSHeader: "true",
+			},
+			validate: func(f types.Frontend) bool {
+				return f.Headers.ForceSTSHeader
+			},
+		},
+		{
 			desc: "Has FrameDeny enabled",
 			labels: map[string]string{
 				label.TraefikEnable:            "true",
@@ -312,6 +403,85 @@ func TestFrontendLabelConfig(t *testing.T) {
 			},
 			validate: func(f types.Frontend) bool { return !f.Headers.FrameDeny },
 		},
+		//Todo: Is this behaviour correct "SAMEORIGIN" => "[SAMEORIGIN]"?
+		{
+			desc: "hasCustomFrameOptionsValueHeaders",
+			labels: map[string]string{
+				label.TraefikEnable:                          "true",
+				label.TraefikFrontendCustomFrameOptionsValue: "SAMEORIGIN",
+			},
+			validate: func(f types.Frontend) bool { return f.Headers.CustomFrameOptionsValue == "[SAMEORIGIN]" },
+		},
+		{
+			desc: "Has ContentTypeNosniffHeaders set",
+			labels: map[string]string{
+				label.TraefikEnable:                     "true",
+				label.TraefikFrontendContentTypeNosniff: "true",
+			},
+			validate: func(f types.Frontend) bool {
+				return f.Headers.ContentTypeNosniff
+			},
+		},
+		{
+			desc: "Has BrowserXSSFilterHeaders set",
+			labels: map[string]string{
+				label.TraefikEnable:                   "true",
+				label.TraefikFrontendBrowserXSSFilter: "true",
+			},
+			validate: func(f types.Frontend) bool {
+				return f.Headers.BrowserXSSFilter
+			},
+		},
+		{
+			desc: "Has ContentSecurityPolicyHeaders set",
+			labels: map[string]string{
+				label.TraefikEnable:                        "true",
+				label.TraefikFrontendContentSecurityPolicy: "plugin-types image/png application/pdf; sandbox",
+			},
+			validate: func(f types.Frontend) bool {
+				return f.Headers.ContentSecurityPolicy == "[plugin-types image/png application/pdf; sandbox]"
+			},
+		},
+		{
+			desc: "Has PublicKeyHeaders set",
+			labels: map[string]string{
+				label.TraefikEnable:            "true",
+				label.TraefikFrontendPublicKey: "somekeydata",
+			},
+			validate: func(f types.Frontend) bool {
+				return f.Headers.PublicKey == "[somekeydata]"
+			},
+		},
+		{
+			desc: "Has ReferrerPolicyHeaders set",
+			labels: map[string]string{
+				label.TraefikEnable:                 "true",
+				label.TraefikFrontendReferrerPolicy: "same-origin",
+			},
+			validate: func(f types.Frontend) bool {
+				return f.Headers.ReferrerPolicy == "[same-origin]"
+			},
+		},
+		{
+			desc: "Has IsDevelopmentHeaders set",
+			labels: map[string]string{
+				label.TraefikEnable:                "true",
+				label.TraefikFrontendIsDevelopment: "true",
+			},
+			validate: func(f types.Frontend) bool {
+				return f.Headers.IsDevelopment
+			},
+		},
+		{
+			desc: "Has AllowedhostHeaders set",
+			labels: map[string]string{
+				label.TraefikEnable:               "true",
+				label.TraefikFrontendAllowedHosts: "host1, host2",
+			},
+			validate: func(f types.Frontend) bool {
+				return f.Headers.AllowedHosts[0] == "host1"
+			},
+		},
 		{
 			desc: "Has RequestHeaders set",
 			labels: map[string]string{
@@ -323,13 +493,23 @@ func TestFrontendLabelConfig(t *testing.T) {
 			},
 		},
 		{
-			desc: "Has rule set",
+			desc: "Has ResponseHeaders set",
 			labels: map[string]string{
-				label.TraefikEnable:                    "true",
-				label.TraefikFrontendRule + ".default": "Path: /",
+				label.TraefikEnable:                  "true",
+				label.TraefikFrontendResponseHeaders: "X-Testing:testing||X-Testing2:testing2",
 			},
 			validate: func(f types.Frontend) bool {
-				return len(f.Routes) == 1 && f.Routes[label.TraefikFrontendRule+".default"].Rule == "Path: /"
+				return len(f.Headers.CustomResponseHeaders) == 2 && f.Headers.CustomResponseHeaders["X-Testing"] == "testing"
+			},
+		},
+		{
+			desc: "Has SSLProxyHeaders set",
+			labels: map[string]string{
+				label.TraefikEnable:                  "true",
+				label.TraefikFrontendSSLProxyHeaders: "X-Testing:testing||X-Testing2:testing2",
+			},
+			validate: func(f types.Frontend) bool {
+				return len(f.Headers.SSLProxyHeaders) == 2 && f.Headers.SSLProxyHeaders["X-Testing"] == "testing"
 			},
 		},
 	}

--- a/servicefabric_test.go
+++ b/servicefabric_test.go
@@ -7,89 +7,92 @@ import (
 	"testing"
 	"time"
 
+	"github.com/containous/traefik/provider/label"
 	"github.com/containous/traefik/safe"
 	"github.com/containous/traefik/types"
 	sf "github.com/jjcollinge/servicefabric"
 )
 
-func TestUpdateConfig(t *testing.T) {
-	apps := &sf.ApplicationItemsPage{
-		ContinuationToken: nil,
-		Items: []sf.ApplicationItem{
-			{
-				HealthState: "Ok",
-				ID:          "TestApplication",
-				Name:        "fabric:/TestApplication",
-				Parameters: []*sf.AppParameter{
-					{Key: "TraefikPublish", Value: "fabric:/TestApplication/TestService"},
-				},
-				Status:      "Ready",
-				TypeName:    "TestApplicationType",
-				TypeVersion: "1.0.0",
+var apps = &sf.ApplicationItemsPage{
+	ContinuationToken: nil,
+	Items: []sf.ApplicationItem{
+		{
+			HealthState: "Ok",
+			ID:          "TestApplication",
+			Name:        "fabric:/TestApplication",
+			Parameters: []*sf.AppParameter{
+				{Key: "TraefikPublish", Value: "fabric:/TestApplication/TestService"},
 			},
+			Status:      "Ready",
+			TypeName:    "TestApplicationType",
+			TypeVersion: "1.0.0",
 		},
-	}
-	services := &sf.ServiceItemsPage{
-		ContinuationToken: nil,
-		Items: []sf.ServiceItem{
-			{
-				HasPersistedState: true,
-				HealthState:       "Ok",
-				ID:                "TestApplication/TestService",
-				IsServiceGroup:    false,
-				ManifestVersion:   "1.0.0",
-				Name:              "fabric:/TestApplication/TestService",
-				ServiceKind:       "Stateless",
-				ServiceStatus:     "Active",
-				TypeName:          "TestServiceType",
-			},
+	},
+}
+var services = &sf.ServiceItemsPage{
+	ContinuationToken: nil,
+	Items: []sf.ServiceItem{
+		{
+			HasPersistedState: true,
+			HealthState:       "Ok",
+			ID:                "TestApplication/TestService",
+			IsServiceGroup:    false,
+			ManifestVersion:   "1.0.0",
+			Name:              "fabric:/TestApplication/TestService",
+			ServiceKind:       "Stateless",
+			ServiceStatus:     "Active",
+			TypeName:          "TestServiceType",
 		},
-	}
-	partitions := &sf.PartitionItemsPage{
-		ContinuationToken: nil,
-		Items: []sf.PartitionItem{
-			{
-				CurrentConfigurationEpoch: sf.ConfigurationEpoch{
-					ConfigurationVersion: "12884901891",
-					DataLossVersion:      "131496928071680379",
-				},
-				HealthState:       "Ok",
-				MinReplicaSetSize: 1,
-				PartitionInformation: sf.PartitionInformation{
-					HighKey:              "9223372036854775807",
-					ID:                   "bce46a8c-b62d-4996-89dc-7ffc00a96902",
-					LowKey:               "-9223372036854775808",
-					ServicePartitionKind: "Int64Range",
-				},
-				PartitionStatus:      "Ready",
-				ServiceKind:          "Stateless",
-				TargetReplicaSetSize: 1,
-			},
-		},
-	}
-	instances := &sf.InstanceItemsPage{
-		ContinuationToken: nil,
-		Items: []sf.InstanceItem{
-			{
-				ReplicaItemBase: &sf.ReplicaItemBase{
-					Address:                      `{"Endpoints":{"":"http://localhost:8081"}}`,
-					HealthState:                  "Ok",
-					LastInBuildDurationInSeconds: "3",
-					NodeName:                     "_Node_0",
-					ReplicaStatus:                "Ready",
-					ServiceKind:                  "Stateless",
-				},
-				ID: "131497042182378182",
-			},
-		},
-	}
+	},
+}
 
-	labels := map[string]string{
-		"expose":                      "true",
-		"frontend.rule.default":       "Path: /",
-		"backend.loadbalancer.method": "wrr",
-		"backend.circuitbreaker":      "NetworkErrorRatio() > 0.5",
-	}
+var partitions = &sf.PartitionItemsPage{
+	ContinuationToken: nil,
+	Items: []sf.PartitionItem{
+		{
+			CurrentConfigurationEpoch: sf.ConfigurationEpoch{
+				ConfigurationVersion: "12884901891",
+				DataLossVersion:      "131496928071680379",
+			},
+			HealthState:       "Ok",
+			MinReplicaSetSize: 1,
+			PartitionInformation: sf.PartitionInformation{
+				HighKey:              "9223372036854775807",
+				ID:                   "bce46a8c-b62d-4996-89dc-7ffc00a96902",
+				LowKey:               "-9223372036854775808",
+				ServicePartitionKind: "Int64Range",
+			},
+			PartitionStatus:      "Ready",
+			ServiceKind:          "Stateless",
+			TargetReplicaSetSize: 1,
+		},
+	},
+}
+var instances = &sf.InstanceItemsPage{
+	ContinuationToken: nil,
+	Items: []sf.InstanceItem{
+		{
+			ReplicaItemBase: &sf.ReplicaItemBase{
+				Address:                      `{"Endpoints":{"":"http://localhost:8081"}}`,
+				HealthState:                  "Ok",
+				LastInBuildDurationInSeconds: "3",
+				NodeName:                     "_Node_0",
+				ReplicaStatus:                "Ready",
+				ServiceKind:                  "Stateless",
+			},
+			ID: "131497042182378182",
+		},
+	},
+}
+
+var labels = map[string]string{
+	label.SuffixEnable:            "true",
+	"frontend.rule.default":       "Path: /",
+	"backend.loadbalancer.method": "wrr",
+	"backend.circuitbreaker":      "NetworkErrorRatio() > 0.5",
+}
+
+func TestUpdateConfig(t *testing.T) {
 
 	client := &clientMock{
 		applications: apps,
@@ -103,7 +106,7 @@ func TestUpdateConfig(t *testing.T) {
 		ProviderName: "servicefabric",
 		Configuration: &types.Configuration{
 			Frontends: map[string]*types.Frontend{
-				"fabric:/TestApplication/TestService": {
+				"frontend-fabric:/TestApplication/TestService": {
 					EntryPoints: []string{},
 					Backend:     "fabric:/TestApplication/TestService",
 					Routes: map[string]types.Route{
@@ -159,6 +162,112 @@ func TestUpdateConfig(t *testing.T) {
 		}
 	case <-timeout:
 		t.Error("Provider failed to return configuration")
+	}
+}
+
+func TestFrontendLabelConfig(t *testing.T) {
+	testCases := []struct {
+		desc     string
+		labels   map[string]string
+		validate func(types.Frontend) bool
+	}{
+		{
+			desc: "Has passTLSCert enabled",
+			labels: map[string]string{
+				label.SuffixEnable:              "true",
+				label.SuffixFrontendPassTLSCert: "true",
+			},
+			validate: func(f types.Frontend) bool { return f.PassTLSCert },
+		},
+		{
+			desc: "Has passTLSCert disabled",
+			labels: map[string]string{
+				label.SuffixEnable:              "true",
+				label.SuffixFrontendPassTLSCert: "false",
+			},
+			validate: func(f types.Frontend) bool { return !f.PassTLSCert },
+		},
+		{
+			desc: "Has FrameDeny enabled",
+			labels: map[string]string{
+				label.SuffixEnable:                   "true",
+				label.SuffixFrontendHeadersFrameDeny: "true",
+			},
+			validate: func(f types.Frontend) bool { return f.Headers.FrameDeny },
+		},
+		{
+			desc: "Has FrameDeny disabled",
+			labels: map[string]string{
+				label.SuffixEnable:                   "true",
+				label.SuffixFrontendHeadersFrameDeny: "false",
+			},
+			validate: func(f types.Frontend) bool { return !f.Headers.FrameDeny },
+		},
+		{
+			desc: "Has RequestHeaders set",
+			labels: map[string]string{
+				label.SuffixEnable:                 "true",
+				label.SuffixFrontendRequestHeaders: "X-Testing:testing||X-Testing2:testing2",
+			},
+			validate: func(f types.Frontend) bool {
+				return len(f.Headers.CustomRequestHeaders) == 2 && f.Headers.CustomRequestHeaders["X-Testing"] == "testing"
+			},
+		},
+	}
+
+	provider := Provider{}
+	ctx := context.Background()
+	pool := safe.NewPool(ctx)
+	defer pool.Stop()
+
+	for _, test := range testCases {
+		test := test
+		t.Run(test.desc, func(t *testing.T) {
+			t.Parallel()
+
+			client := &clientMock{
+				applications: apps,
+				services:     services,
+				partitions:   partitions,
+				replicas:     nil,
+				instances:    instances,
+				labels:       test.labels,
+			}
+			configurationChan := make(chan types.ConfigMessage)
+			err := provider.updateConfig(configurationChan, pool, client, time.Millisecond*100)
+
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			timeout := make(chan string, 1)
+			go func() {
+				time.Sleep(time.Second * 2)
+				timeout <- "Timeout triggered"
+			}()
+
+			select {
+			case <-timeout:
+				t.Error("Provider failed to return configuration")
+			case actual := <-configurationChan:
+				if len(actual.Configuration.Frontends) != 1 {
+					t.Error("No frontends present in the config")
+				}
+
+				for _, frontend := range actual.Configuration.Frontends {
+					if frontend == nil {
+						t.Error("Frontend is nil")
+					}
+					if !test.validate(*frontend) {
+						frontendJSON, _ := getJSON(frontend)
+						t.Log(frontendJSON)
+						t.Fail()
+					}
+					break
+
+				}
+			}
+		})
 	}
 }
 
@@ -332,6 +441,14 @@ func TestGetReplicaDefaultEndpoint(t *testing.T) {
 	}
 }
 
+func getJSON(i interface{}) (string, error) {
+	jsonBytes, err := json.Marshal(i)
+	if err != nil {
+		return "", err
+	}
+	return string(jsonBytes), nil
+}
+
 func compareConfigurations(actual, expected types.ConfigMessage) error {
 	if actual.ProviderName == expected.ProviderName {
 		if len(actual.Configuration.Frontends) == len(expected.Configuration.Frontends) {
@@ -349,7 +466,7 @@ func compareConfigurations(actual, expected types.ConfigMessage) error {
 				expectedFrontendsStr := string(expectedFrontends)
 
 				if actualFrontendsStr != expectedFrontendsStr {
-					return fmt.Errorf("backend configuration differs from expected configuration: got %q, want %q", actualFrontendsStr, expectedFrontendsStr)
+					return fmt.Errorf("backend configuration differs from expected configuration: got %q, expected %q", actualFrontendsStr, expectedFrontendsStr)
 				}
 
 				actualBackends, err := json.Marshal(actual.Configuration.Backends)
@@ -368,9 +485,9 @@ func compareConfigurations(actual, expected types.ConfigMessage) error {
 				}
 				return nil
 			}
-			return fmt.Errorf("backends count differs from expected: got %+v, want %+v", actual.Configuration.Backends, expected.Configuration.Backends)
+			return fmt.Errorf("backends count differs from expected: got %+v, expected %+v", actual.Configuration.Backends, expected.Configuration.Backends)
 		}
-		return fmt.Errorf("frontends count differs from expected: got %+v, want %+v", actual.Configuration.Frontends, expected.Configuration.Frontends)
+		return fmt.Errorf("frontends count differs from expected: got %+v, expected %+v", actual.Configuration.Frontends, expected.Configuration.Frontends)
 	}
-	return fmt.Errorf("provider name differs from expected: got %q, want %q", actual.ProviderName, expected.ProviderName)
+	return fmt.Errorf("provider name differs from expected: got %q, expected %q", actual.ProviderName, expected.ProviderName)
 }

--- a/servicefabric_test.go
+++ b/servicefabric_test.go
@@ -3,7 +3,6 @@ package servicefabric
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 	"testing"
 	"time"
 
@@ -82,16 +81,26 @@ var instances = &sf.InstanceItemsPage{
 			},
 			ID: "131497042182378182",
 		},
+		{ //Include a failed service in test data
+			ReplicaItemBase: &sf.ReplicaItemBase{
+				Address:                      `{"Endpoints":{"":"http://anotheraddress:8081"}}`,
+				HealthState:                  "Error",
+				LastInBuildDurationInSeconds: "3",
+				NodeName:                     "_Node_0",
+				ReplicaStatus:                "Down", // status is currently down.
+				ServiceKind:                  "Stateless",
+			},
+			ID: "131497042182378183",
+		},
 	},
 }
 
 var labels = map[string]string{
-	label.SuffixEnable:            "true",
-	"frontend.rule.default":       "Path: /",
-	"backend.loadbalancer.method": "wrr",
-	"backend.circuitbreaker":      "NetworkErrorRatio() > 0.5",
+	label.SuffixEnable: "true",
 }
 
+// TestUpdateconfig - This test ensures the provider returns a configuration message to
+// the configuration channel when run.
 func TestUpdateConfig(t *testing.T) {
 
 	client := &clientMock{
@@ -101,38 +110,6 @@ func TestUpdateConfig(t *testing.T) {
 		replicas:     nil,
 		instances:    instances,
 		labels:       labels,
-	}
-	expected := types.ConfigMessage{
-		ProviderName: "servicefabric",
-		Configuration: &types.Configuration{
-			Frontends: map[string]*types.Frontend{
-				"frontend-fabric:/TestApplication/TestService": {
-					EntryPoints: []string{},
-					Backend:     "fabric:/TestApplication/TestService",
-					Routes: map[string]types.Route{
-						"frontend.rule.default": {
-							Rule: "Path: /",
-						},
-					},
-				},
-			},
-			Backends: map[string]*types.Backend{
-				"fabric:/TestApplication/TestService": {
-					LoadBalancer: &types.LoadBalancer{
-						Method: "wrr",
-					},
-					CircuitBreaker: &types.CircuitBreaker{
-						Expression: "NetworkErrorRatio() > 0.5",
-					},
-					Servers: map[string]types.Server{
-						"131497042182378182": {
-							URL:    "http://localhost:8081",
-							Weight: 1,
-						},
-					},
-				},
-			},
-		},
 	}
 
 	provider := Provider{}
@@ -153,15 +130,74 @@ func TestUpdateConfig(t *testing.T) {
 	}()
 
 	select {
-	case actual := <-configurationChan:
-		err := compareConfigurations(actual, expected)
-		if err != nil {
-			res, _ := json.Marshal(actual)
-			t.Log(string(res))
-			t.Error(err)
-		}
+	case <-configurationChan:
+		t.Log("Received configuration object")
 	case <-timeout:
 		t.Error("Provider failed to return configuration")
+	}
+}
+
+// TestServicesPresentInConfig tests that the basic services provide by SF
+// are return in the configuration object
+func TestServicesPresentInConfig(t *testing.T) {
+	provider := Provider{}
+	client := &clientMock{
+		applications: apps,
+		services:     services,
+		partitions:   partitions,
+		replicas:     nil,
+		instances:    instances,
+		labels:       labels,
+	}
+	config, err := provider.buildConfiguration(client)
+
+	if err != nil {
+		t.Error(err)
+	}
+
+	testCases := []struct {
+		desc  string
+		check func(types.Configuration) bool
+	}{
+		{
+			desc:  "Has 1 Frontend",
+			check: func(c types.Configuration) bool { return len(c.Frontends) == 1 },
+		},
+		{
+			desc:  "Has 1 backend",
+			check: func(c types.Configuration) bool { return len(c.Backends) == 1 },
+		},
+		{
+			desc: "Backend for 'fabric:/TestApplication/TestService' exists",
+			check: func(c types.Configuration) bool {
+				_, exists := config.Backends["fabric:/TestApplication/TestService"]
+				return exists
+			},
+		},
+		{
+			desc: "Backend has 1 server",
+			check: func(c types.Configuration) bool {
+				backend := config.Backends["fabric:/TestApplication/TestService"]
+				return len(backend.Servers) == 1
+			},
+		},
+		{
+			desc: "Backend server has url 'http://localhost:8081'",
+			check: func(c types.Configuration) bool {
+				backend := config.Backends["fabric:/TestApplication/TestService"]
+				return backend.Servers["131497042182378182"].URL == "http://localhost:8081"
+			},
+		},
+	}
+
+	for _, test := range testCases {
+		test := test
+		t.Run(test.desc, func(t *testing.T) {
+			t.Parallel()
+			if !test.check(*config) {
+				t.Errorf("Check failed: %v", getJSON(config))
+			}
+		})
 	}
 }
 
@@ -243,8 +279,67 @@ func TestFrontendLabelConfig(t *testing.T) {
 					t.Error("Frontend is nil")
 				}
 				if !test.validate(*frontend) {
-					frontendJSON, _ := getJSON(frontend)
-					t.Log(frontendJSON)
+					t.Log(getJSON(frontend))
+					t.Fail()
+				}
+			}
+		})
+	}
+}
+
+func TestBackendLabelConfig(t *testing.T) {
+	testCases := []struct {
+		desc     string
+		labels   map[string]string
+		validate func(types.Backend) bool
+	}{
+		{
+			desc: "Has DRR Loadbalencer",
+			labels: map[string]string{
+				label.SuffixEnable:                    "true",
+				label.SuffixBackendLoadBalancerMethod: "drr",
+			},
+			validate: func(d types.Backend) bool { return d.LoadBalancer.Method == "drr" },
+		},
+		{
+			desc: "Has circuit breaker set",
+			labels: map[string]string{
+				label.SuffixEnable:                "true",
+				label.SuffixBackendCircuitBreaker: "NetworkErrorRatio() > 0.5",
+			},
+			validate: func(d types.Backend) bool { return d.CircuitBreaker.Expression == "NetworkErrorRatio() > 0.5" },
+		},
+	}
+
+	for _, test := range testCases {
+		test := test
+		t.Run(test.desc, func(t *testing.T) {
+			t.Parallel()
+			provider := Provider{}
+			client := &clientMock{
+				applications: apps,
+				services:     services,
+				partitions:   partitions,
+				replicas:     nil,
+				instances:    instances,
+				labels:       test.labels,
+			}
+			config, err := provider.buildConfiguration(client)
+
+			if err != nil {
+				t.Error(err)
+			}
+
+			if len(config.Backends) != 1 {
+				t.Error("No backends present in the config")
+			}
+
+			for _, backend := range config.Backends {
+				if backend == nil {
+					t.Error("backend is nil")
+				}
+				if !test.validate(*backend) {
+					t.Log(getJSON(backend))
 					t.Fail()
 				}
 			}
@@ -422,53 +517,10 @@ func TestGetReplicaDefaultEndpoint(t *testing.T) {
 	}
 }
 
-func getJSON(i interface{}) (string, error) {
+func getJSON(i interface{}) string {
 	jsonBytes, err := json.Marshal(i)
 	if err != nil {
-		return "", err
+		panic(err)
 	}
-	return string(jsonBytes), nil
-}
-
-func compareConfigurations(actual, expected types.ConfigMessage) error {
-	if actual.ProviderName == expected.ProviderName {
-		if len(actual.Configuration.Frontends) == len(expected.Configuration.Frontends) {
-			if len(actual.Configuration.Backends) == len(expected.Configuration.Backends) {
-				actualFrontends, err := json.Marshal(actual.Configuration.Frontends)
-				if err != nil {
-					return err
-				}
-				actualFrontendsStr := string(actualFrontends)
-
-				expectedFrontends, err := json.Marshal(expected.Configuration.Frontends)
-				if err != nil {
-					return err
-				}
-				expectedFrontendsStr := string(expectedFrontends)
-
-				if actualFrontendsStr != expectedFrontendsStr {
-					return fmt.Errorf("backend configuration differs from expected configuration: got %q, expected %q", actualFrontendsStr, expectedFrontendsStr)
-				}
-
-				actualBackends, err := json.Marshal(actual.Configuration.Backends)
-				if err != nil {
-					return err
-				}
-				actualBackendsStr := string(actualBackends)
-				expectedBackends, err := json.Marshal(expected.Configuration.Backends)
-				if err != nil {
-					return err
-				}
-				expectedBackendsStr := string(expectedBackends)
-
-				if actualBackendsStr != expectedBackendsStr {
-					return err
-				}
-				return nil
-			}
-			return fmt.Errorf("backends count differs from expected: got %+v, expected %+v", actual.Configuration.Backends, expected.Configuration.Backends)
-		}
-		return fmt.Errorf("frontends count differs from expected: got %+v, expected %+v", actual.Configuration.Frontends, expected.Configuration.Frontends)
-	}
-	return fmt.Errorf("provider name differs from expected: got %q, expected %q", actual.ProviderName, expected.ProviderName)
+	return string(jsonBytes)
 }

--- a/servicefabric_tmpl.go
+++ b/servicefabric_tmpl.go
@@ -2,228 +2,208 @@ package servicefabric
 
 const tmpl = `
 [backends]
-    {{range $aggName, $aggServices := getGroupedServices .Services }}
-      [backends."{{$aggName}}"]
-      {{range $service := $aggServices}}
-        {{range $partition := $service.Partitions}}
-          {{range $instance := $partition.Instances}}
-            [backends."{{$aggName}}".servers."{{$service.ID}}-{{$instance.ID}}"]
-            url = "{{getDefaultEndpoint $instance}}"
-            weight = {{getGroupedWeight $service}}
-          {{end}}
-        {{end}}
-      {{end}}
-    {{end}}
-  {{range $service := .Services}}
-  {{if isEnabled $service}}
-    {{range $partition := $service.Partitions}}
-      {{if isStateless $service}} 
-      [backends."{{$service.Name}}"]
-        [backends."{{$service.Name}}".LoadBalancer]
-        {{if hasLoadBalancerLabel $service}}
-          method = "{{getLoadBalancerMethod $service }}"
+{{range $aggName, $aggServices := getGroupedServices .Services }}
+  [backends."{{ $aggName }}"]
+  {{range $service := $aggServices }}
+  {{range $partition := $service.Partitions }}
+  {{range $instance := $partition.Instances }}
+    [backends."{{ $aggName }}".servers."{{ $service.ID }}-{{ $instance.ID }}"]
+      url = "{{ getDefaultEndpoint $instance }}"
+      weight = {{ getGroupedWeight $service }}
+  {{end}}
+  {{end}}
+  {{end}}
+{{end}}
+
+{{range $service := .Services }}
+  {{if isEnabled $service }}
+    {{range $partition := $service.Partitions }}
+
+      {{if isStateless $service }}
+
+        {{ $backendName := $service.Name }}
+        [backends."{{ $backendName }}"]
+
+        {{ $circuitBreaker := getCircuitBreaker $service }}
+        {{if $circuitBreaker }}
+          [backends."{{ $backendName }}".circuitBreaker]
+            expression = "{{ $circuitBreaker.Expression }}"
         {{end}}
 
-        {{if hasHealthCheckLabels $service}}
-          [backends."{{$service.Name}}".healthcheck]
-          path = "{{getHealthCheckPath $service}}"
-          interval = "{{getHealthCheckInterval $service }}"
-          port = {{getHealthCheckPort $service}}
+        {{ $loadBalancer := getLoadBalancer $service }}
+        {{if $loadBalancer }}
+          [backends."{{ $backendName }}".loadBalancer]
+            method = "{{ $loadBalancer.Method }}"
+            sticky = {{ $loadBalancer.Sticky }}
+            {{if $loadBalancer.Stickiness }}
+            [backends."{{ $backendName }}".loadBalancer.stickiness]
+              cookieName = "{{ $loadBalancer.Stickiness.CookieName }}"
+            {{end}}
         {{end}}
 
-        {{if hasStickinessLabel $service}}
-          [backends."{{$service.Name}}".LoadBalancer.stickiness]
+        {{ $maxConn := getMaxConn $service }}
+        {{if $maxConn }}
+          [backends."{{ $backendName }}".maxConn]
+            extractorFunc = "{{ $maxConn.ExtractorFunc }}"
+            amount = {{ $maxConn.Amount }}
         {{end}}
 
-        sticky = {{getSticky $service}}
-        {{if hasStickinessLabel $service}}
-        [backends."{{$service.Name}}".loadBalancer.stickiness]
-          cookieName = "{{getStickinessCookieName $service}}"
-        {{end}}
-
-        {{if hasCircuitBreakerLabel $service}}
-        [backends."{{$service.Name}}".circuitBreaker]
-          expression = "{{getCircuitBreakerExpression $service}}"
-        {{end}}
-
-        {{if hasMaxConnLabels $service}}
-        [backends."{{$service.Name}}".maxConn]
-          amount = {{getMaxConnAmount $service}}
-          extractorFunc = "{{getMaxConnExtractorFunc $service}}"
+        {{ $healthCheck := getHealthCheck $service }}
+        {{if $healthCheck }}
+          [backends."{{ $backendName }}".healthCheck]
+            path = "{{ $healthCheck.Path }}"
+            port = {{ $healthCheck.Port }}
+            interval = "{{ $healthCheck.Interval }}"
         {{end}}
 
         {{range $instance := $partition.Instances}}
-          [backends."{{$service.Name}}".servers."{{$instance.ID}}"]
-          url = "{{getDefaultEndpoint $instance}}"
-          weight = {{getLabelValue $service "backend.weight" "1"}}
+          [backends."{{ $service.Name }}".servers."{{ $instance.ID }}"]
+            url = "{{ getDefaultEndpoint $instance }}"
+            weight = {{ getLabelValue $service "backend.weight" "1" }}
         {{end}}
+
       {{else if isStateful $service}}
+
         {{range $replica := $partition.Replicas}}
           {{if isPrimary $replica}}
-
-            {{$backendName := getBackendName $service $partition}}
-            [backends."{{$backendName}}".servers."{{$replica.ID}}"]
-            url = "{{getDefaultEndpoint $replica}}"
-            weight = 1
+            {{ $backendName := getBackendName $service $partition }}
+            [backends."{{ $backendName }}".servers."{{ $replica.ID }}"]
+              url = "{{ getDefaultEndpoint $replica }}"
+							weight = 1
 
             [backends."{{$backendName}}".LoadBalancer]
-            method = "drr"
-
-            [backends."{{$backendName}}".circuitbreaker]
-            expression = "NetworkErrorRatio() > 0.5"
+              method = "drr"
 
           {{end}}
         {{end}}
+
       {{end}}
+
     {{end}}
   {{end}}
 {{end}}
 
 [frontends]
-{{range $groupName, $groupServices := getGroupedServices .Services}}
-  {{$service := index $groupServices 0}}
-    [frontends."{{$groupName}}"]
-    backend = "{{$groupName}}"
-
+{{range $groupName, $groupServices := getGroupedServices .Services }}
+  {{ $service := index $groupServices 0 }}
+  [frontends."{{ $groupName }}"]
+    backend = "{{ $groupName }}"
     priority = 50
 
-    {{range $key, $value := getFrontendRules $service}}
-    [frontends."{{$groupName}}".routes."{{$key}}"]
-    rule = "{{$value}}"
-    {{end}}
-{{end}}
-{{range $service := .Services}}
-  {{if isEnabled $service}}
-    {{$frontend := $service.Name}}
-    {{if isStateless $service}}
-    
-    [frontends."frontend-{{$frontend}}"]
-    backend = "{{$service.Name}}"
-
-    passHostHeader = {{getPassHostHeader $service }}
-
-    passTLSCert = {{getPassTLSCert $service}}
-
-    {{if getWhitelistSourceRange $service}}
-    whitelistSourceRange = [{{range getWhitelistSourceRange $service}}
-      "{{.}}",
-      {{end}}]
-    {{end}}
-
-    priority = {{ getPriority $service }}
-
-    {{if hasBasicAuth $service}}
-      basicAuth = [{{range getBasicAuth $service }}
-      "{{.}}",
-      {{end}}]
-    {{end}}
-
-    {{if hasEntryPoints $service}}
-    entryPoints = [{{range getEntryPoints $service}}
-    "{{.}}",
-    {{end}}]
-    {{end}}
-    
-    {{ if hasHeaders $service}}
-    [frontends."frontend-{{$frontend}}".headers]
-      {{if hasSSLRedirectHeaders $service}}
-      SSLRedirect = {{getSSLRedirectHeaders $service}}
-      {{end}}
-      {{if hasSSLTemporaryRedirectHeaders $service}}
-      SSLTemporaryRedirect = {{getSSLTemporaryRedirectHeaders $service}}
-      {{end}}
-      {{if hasSSLHostHeaders $service}}
-      SSLHost = "{{getSSLHostHeaders $service}}"
-      {{end}}
-      {{if hasSTSSecondsHeaders $service}}
-      STSSeconds = {{getSTSSecondsHeaders $service}}
-      {{end}}
-      {{if hasSTSIncludeSubdomainsHeaders $service}}
-      STSIncludeSubdomains = {{getSTSIncludeSubdomainsHeaders $service}}
-      {{end}}
-      {{if hasSTSPreloadHeaders $service}}
-      STSPreload = {{getSTSPreloadHeaders $service}}
-      {{end}}
-      {{if hasForceSTSHeaderHeaders $service}}
-      ForceSTSHeader = {{getForceSTSHeaderHeaders $service}}
-      {{end}}
-      {{if hasFrameDenyHeaders $service}}
-      FrameDeny = {{getFrameDenyHeaders $service}}
-      {{end}}
-      {{if hasCustomFrameOptionsValueHeaders $service}}
-      CustomFrameOptionsValue = "{{getCustomFrameOptionsValueHeaders $service}}"
-      {{end}}
-      {{if hasContentTypeNosniffHeaders $service}}
-      ContentTypeNosniff = {{getContentTypeNosniffHeaders $service}}
-      {{end}}
-      {{if hasBrowserXSSFilterHeaders $service}}
-      BrowserXSSFilter = {{getBrowserXSSFilterHeaders $service}}
-      {{end}}
-      {{if hasContentSecurityPolicyHeaders $service}}
-      ContentSecurityPolicy = "{{getContentSecurityPolicyHeaders $service}}"
-      {{end}}
-      {{if hasPublicKeyHeaders $service}}
-      PublicKey = "{{getPublicKeyHeaders $service}}"
-      {{end}}
-      {{if hasReferrerPolicyHeaders $service}}
-      ReferrerPolicy = "{{getReferrerPolicyHeaders $service}}"
-      {{end}}
-      {{if hasIsDevelopmentHeaders $service}}
-      IsDevelopment = {{getIsDevelopmentHeaders $service}}
-      {{end}}
-
-      {{if hasAllowedHostsHeaders $service}}
-      AllowedHosts = [{{range getAllowedHostsHeaders $service}}
-        "{{.}}",
-        {{end}}]
-      {{end}}
-
-      {{if hasHostsProxyHeaders $service}}
-      HostsProxyHeaders = [{{range getHostsProxyHeaders $service}}
-        "{{.}}",
-        {{end}}]
-      {{end}}
-
-      {{if hasRequestHeaders $service}}
-        [frontends."frontend-{{$frontend}}".headers.customRequestHeaders]
-        {{range $k, $v := getRequestHeaders $service}}
-        {{$k}} = "{{$v}}"
-        {{end}}
-      {{end}}
-
-      {{if hasResponseHeaders $service}}
-      [frontends."frontend-{{$frontend}}".headers.customResponseHeaders]
-        {{range $k, $v := getResponseHeaders $service}}
-        {{$k}} = "{{$v}}"
-        {{end}}
-      {{end}}
-
-      {{if hasSSLProxyHeaders $service}}
-      [frontends."frontend-{{$frontend}}".headers.SSLProxyHeaders]
-        {{range $k, $v := getSSLProxyHeaders $service}}
-        {{$k}} = "{{$v}}"
-        {{end}}
-      {{end}}
-    {{end}}
-
-    {{range $key, $value := getFrontendRules $service}}
-    [frontends."frontend-{{$frontend}}".routes."{{$key}}"]
-    rule = "{{$value}}"
-    {{end}}
-
-    {{else if isStateful $service}}
-      {{range $partition := $service.Partitions}}
-        {{$partitionId := $partition.PartitionInformation.ID}}
-
-        {{if hasLabel $service "frontend.rule"}}
-          [frontends."{{$service.Name}}/{{$partitionId}}"]
-          backend = "{{getBackendName $service.Name $partition}}"
-          [frontends."{{$service.Name}}/{{$partitionId}}".routes.default]
-          rule = {{getLabelValue $service "frontend.rule.partition.$partitionId" ""}}
-
-      {{end}}
-    {{end}}
+  {{range $key, $value := getFrontendRules $service }}
+    [frontends."{{ $groupName }}".routes."{{ $key }}"]
+      rule = "{{ $value }}"
   {{end}}
 {{end}}
+
+{{range $service := .Services }}
+  {{if isEnabled $service }}
+    {{ $frontendName := $service.Name }}
+
+    {{if isStateless $service }}
+
+      [frontends."frontend-{{ $frontendName }}"]
+        backend = "{{ $service.Name }}"
+        passHostHeader = {{ getPassHostHeader $service }}
+        passTLSCert = {{ getPassTLSCert $service }}
+        priority = {{ getPriority $service }}
+  
+        {{ $entryPoints := getEntryPoints $service }}
+        {{if $entryPoints }}
+        entryPoints = [{{range $entryPoints }}
+          "{{.}}",
+          {{end}}]
+        {{end}}
+  
+        {{ $whitelistSourceRange := getWhitelistSourceRange $service }}
+        {{if $whitelistSourceRange }}
+        whitelistSourceRange = [{{range $whitelistSourceRange }}
+          "{{.}}",
+          {{end}}]
+        {{end}}
+  
+        {{ $basicAuth := getBasicAuth $service }}
+        {{if $basicAuth }}
+         basicAuth = [{{range $basicAuth }}
+          "{{.}}",
+          {{end}}]
+        {{end}}
+
+        {{ $headers := getHeaders $service }}
+        {{if $headers }}
+        [frontends."frontend-{{ $frontendName }}".headers]
+          SSLRedirect = {{ $headers.SSLRedirect }}
+          SSLTemporaryRedirect = {{ $headers.SSLTemporaryRedirect }}
+          SSLHost = "{{ $headers.SSLHost }}"
+          STSSeconds = {{ $headers.STSSeconds }}
+          STSIncludeSubdomains = {{ $headers.STSIncludeSubdomains }}
+          STSPreload = {{ $headers.STSPreload }}
+          ForceSTSHeader = {{ $headers.ForceSTSHeader }}
+          FrameDeny = {{ $headers.FrameDeny }}
+          CustomFrameOptionsValue = "{{ $headers.CustomFrameOptionsValue }}"
+          ContentTypeNosniff = {{ $headers.ContentTypeNosniff }}
+          BrowserXSSFilter = {{ $headers.BrowserXSSFilter }}
+          CustomBrowserXSSValue = "{{ $headers.CustomBrowserXSSValue }}"
+          ContentSecurityPolicy = "{{ $headers.ContentSecurityPolicy }}"
+          PublicKey = "{{ $headers.PublicKey }}"
+          ReferrerPolicy = "{{ $headers.ReferrerPolicy }}"
+          IsDevelopment = {{ $headers.IsDevelopment }}
+  
+          {{if $headers.AllowedHosts }}
+          AllowedHosts = [{{range $headers.AllowedHosts }}
+            "{{.}}",
+            {{end}}]
+          {{end}}
+  
+          {{if $headers.HostsProxyHeaders }}
+          HostsProxyHeaders = [{{range $headers.HostsProxyHeaders }}
+            "{{.}}",
+            {{end}}]
+          {{end}}
+  
+          {{if $headers.CustomRequestHeaders }}
+          [frontends."frontend-{{ $frontendName }}".headers.customRequestHeaders]
+            {{range $k, $v := $headers.CustomRequestHeaders }}
+            {{$k}} = "{{$v}}"
+            {{end}}
+          {{end}}
+  
+          {{if $headers.CustomResponseHeaders }}
+          [frontends."frontend-{{ $frontendName }}".headers.customResponseHeaders]
+            {{range $k, $v := $headers.CustomResponseHeaders }}
+            {{$k}} = "{{$v}}"
+            {{end}}
+          {{end}}
+  
+          {{if $headers.SSLProxyHeaders }}
+          [frontends."frontend-{{ $frontendName }}".headers.SSLProxyHeaders]
+            {{range $k, $v := $headers.SSLProxyHeaders }}
+            {{$k}} = "{{$v}}"
+            {{end}}
+          {{end}}
+        {{end}}
+  
+      {{range $key, $value := getFrontendRules $service }}
+        [frontends."frontend-{{ $frontendName }}".routes."{{ $key }}"]
+          rule = "{{ $value }}"
+      {{end}}
+
+    {{else if isStateful $service}}
+
+      {{range $partition := $service.Partitions }}
+        {{ $partitionId := $partition.PartitionInformation.ID }}
+
+        {{if hasLabel $service "frontend.rule" }}
+          [frontends."{{ $service.Name }}/{{ $partitionId }}"]
+            backend = "{{ getBackendName $service.Name $partition }}"
+
+          [frontends."{{ $service.Name }}/{{ $partitionId }}".routes.default]
+            rule = {{ getLabelValue $service "frontend.rule.partition.$partitionId" "" }}
+        {{end}}
+      {{end}}
+
+    {{end}}
+
+  {{end}}
 {{end}}
 `

--- a/servicefabric_tmpl.go
+++ b/servicefabric_tmpl.go
@@ -17,7 +17,7 @@ const tmpl = `
   {{range $service := .Services}}
   {{if isEnabled $service}}
     {{range $partition := $service.Partitions}}
-      {{if eq $partition.ServiceKind "Stateless"}} 
+      {{if isStateless $service}} 
       [backends."{{$service.Name}}"]
         [backends."{{$service.Name}}".LoadBalancer]
         {{if hasLoadBalancerLabel $service}}
@@ -57,7 +57,7 @@ const tmpl = `
           url = "{{getDefaultEndpoint $instance}}"
           weight = {{getLabelValue $service "backend.weight" "1"}}
         {{end}}
-      {{else if eq $partition.ServiceKind "Stateful"}}
+      {{else if isStateful $service}}
         {{range $replica := $partition.Replicas}}
           {{if isPrimary $replica}}
 
@@ -95,7 +95,7 @@ const tmpl = `
 {{range $service := .Services}}
   {{if isEnabled $service}}
     {{$frontend := $service.Name}}
-    {{if eq $service.ServiceKind "Stateless"}}
+    {{if isStateless $service}}
     
     [frontends."frontend-{{$frontend}}"]
     backend = "{{$service.Name}}"
@@ -211,7 +211,7 @@ const tmpl = `
     rule = "{{$value}}"
     {{end}}
 
-    {{else if eq $service.ServiceKind "Stateful"}}
+    {{else if isStateful $service}}
       {{range $partition := $service.Partitions}}
         {{$partitionId := $partition.PartitionInformation.ID}}
 

--- a/servicefabric_tmpl.go
+++ b/servicefabric_tmpl.go
@@ -27,9 +27,9 @@ const tmpl = `
           method = "drr"
         {{end}}
 
-        {{if hasLabel $service "backend.healthcheck"}}
+        {{if hasLabel $service "backend.healthcheck.path"}}
           [backends."{{$service.Name}}".healthcheck]
-          path = "{{getLabelValue $service "backend.healthcheck" ""}}"
+          path = "{{getLabelValue $service "backend.healthcheck.path" ""}}"
           interval = "{{getLabelValue $service "backend.healthcheck.interval" "10s"}}"
         {{end}}
 
@@ -114,8 +114,8 @@ const tmpl = `
       priority = {{getLabelValue $service "frontend.priority" ""}}
     {{end}}
 
-    {{if hasLabel $service "frontend.basicAuth"}}
-      basicAuth = {{getLabelValue $service "frontend.basicAuth" ""}}
+    {{if hasLabel $service "frontend.auth.basic"}}
+      basicAuth = {{getLabelValue $service "frontend.auth.basic" ""}}
     {{end}}
 
     {{if hasLabel $service "frontend.entryPoints"}}

--- a/servicefabric_tmpl.go
+++ b/servicefabric_tmpl.go
@@ -61,7 +61,7 @@ const tmpl = `
         {{range $replica := $partition.Replicas}}
           {{if isPrimary $replica}}
 
-            {{$backendName := getBackendName $service.Name $partition}}
+            {{$backendName := getBackendName $service $partition}}
             [backends."{{$backendName}}".servers."{{$replica.ID}}"]
             url = "{{getDefaultEndpoint $replica}}"
             weight = 1

--- a/servicefabric_tmpl.go
+++ b/servicefabric_tmpl.go
@@ -124,15 +124,85 @@ const tmpl = `
     {{end}}]
     {{end}}
     
+    {{ if hasHeaders $service}}
     [frontends."frontend-{{$frontend}}".headers]
-    {{if hasFrameDenyHeaders $service}}
-    FrameDeny = {{getFrameDenyHeaders $service}}
-    {{end}}
+      {{if hasSSLRedirectHeaders $service}}
+      SSLRedirect = {{getSSLRedirectHeaders $service}}
+      {{end}}
+      {{if hasSSLTemporaryRedirectHeaders $service}}
+      SSLTemporaryRedirect = {{getSSLTemporaryRedirectHeaders $service}}
+      {{end}}
+      {{if hasSSLHostHeaders $service}}
+      SSLHost = "{{getSSLHostHeaders $service}}"
+      {{end}}
+      {{if hasSTSSecondsHeaders $service}}
+      STSSeconds = {{getSTSSecondsHeaders $service}}
+      {{end}}
+      {{if hasSTSIncludeSubdomainsHeaders $service}}
+      STSIncludeSubdomains = {{getSTSIncludeSubdomainsHeaders $service}}
+      {{end}}
+      {{if hasSTSPreloadHeaders $service}}
+      STSPreload = {{getSTSPreloadHeaders $service}}
+      {{end}}
+      {{if hasForceSTSHeaderHeaders $service}}
+      ForceSTSHeader = {{getForceSTSHeaderHeaders $service}}
+      {{end}}
+      {{if hasFrameDenyHeaders $service}}
+      FrameDeny = {{getFrameDenyHeaders $service}}
+      {{end}}
+      {{if hasCustomFrameOptionsValueHeaders $service}}
+      CustomFrameOptionsValue = "{{getCustomFrameOptionsValueHeaders $service}}"
+      {{end}}
+      {{if hasContentTypeNosniffHeaders $service}}
+      ContentTypeNosniff = {{getContentTypeNosniffHeaders $service}}
+      {{end}}
+      {{if hasBrowserXSSFilterHeaders $service}}
+      BrowserXSSFilter = {{getBrowserXSSFilterHeaders $service}}
+      {{end}}
+      {{if hasContentSecurityPolicyHeaders $service}}
+      ContentSecurityPolicy = "{{getContentSecurityPolicyHeaders $service}}"
+      {{end}}
+      {{if hasPublicKeyHeaders $service}}
+      PublicKey = "{{getPublicKeyHeaders $service}}"
+      {{end}}
+      {{if hasReferrerPolicyHeaders $service}}
+      ReferrerPolicy = "{{getReferrerPolicyHeaders $service}}"
+      {{end}}
+      {{if hasIsDevelopmentHeaders $service}}
+      IsDevelopment = {{getIsDevelopmentHeaders $service}}
+      {{end}}
 
-    {{if hasRequestHeaders $service}}
-      [frontends."frontend-{{$frontend}}".headers.customrequestheaders]
-      {{range $k, $v := getRequestHeaders $service}}
-      {{$k}} = "{{$v}}"
+      {{if hasAllowedHostsHeaders $service}}
+      AllowedHosts = [{{range getAllowedHostsHeaders $service}}
+        "{{.}}",
+        {{end}}]
+      {{end}}
+
+      {{if hasHostsProxyHeaders $service}}
+      HostsProxyHeaders = [{{range getHostsProxyHeaders $service}}
+        "{{.}}",
+        {{end}}]
+      {{end}}
+
+      {{if hasRequestHeaders $service}}
+        [frontends."frontend-{{$frontend}}".headers.customRequestHeaders]
+        {{range $k, $v := getRequestHeaders $service}}
+        {{$k}} = "{{$v}}"
+        {{end}}
+      {{end}}
+
+      {{if hasResponseHeaders $service}}
+      [frontends."frontend-{{$frontend}}".headers.customResponseHeaders]
+        {{range $k, $v := getResponseHeaders $service}}
+        {{$k}} = "{{$v}}"
+        {{end}}
+      {{end}}
+
+      {{if hasSSLProxyHeaders $service}}
+      [frontends."frontend-{{$frontend}}".headers.SSLProxyHeaders]
+        {{range $k, $v := getSSLProxyHeaders $service}}
+        {{$k}} = "{{$v}}"
+        {{end}}
       {{end}}
     {{end}}
 

--- a/servicefabric_tmpl.go
+++ b/servicefabric_tmpl.go
@@ -83,9 +83,7 @@ const tmpl = `
     [frontends."{{$groupName}}"]
     backend = "{{$groupName}}"
 
-    {{if hasLabel $service "frontend.priority"}}
-    priority = 100
-    {{end}}
+    priority = {{ getPriority $service }}
 
     {{range $key, $value := getLabelsWithPrefix $service "frontend.rule"}}
     [frontends."{{$groupName}}".routes."{{$key}}"]
@@ -100,9 +98,7 @@ const tmpl = `
     [frontends."frontend-{{$frontend}}"]
     backend = "{{$service.Name}}"
 
-    {{if hasLabel $service "frontend.passHostHeader"}}
-      passHostHeader = {{getLabelValue $service "frontend.passHostHeader"  ""}}
-    {{end}}
+    passHostHeader = {{getPassHostHeader $service }}
 
     passTLSCert = {{getPassTLSCert $service}}
 
@@ -110,16 +106,16 @@ const tmpl = `
       whitelistSourceRange = {{getLabelValue $service "frontend.whitelistSourceRange"  ""}}
     {{end}}
 
-    {{if hasLabel $service "frontend.priority"}}
-      priority = {{getLabelValue $service "frontend.priority" ""}}
-    {{end}}
+    priority = {{ getPriority $service }}
 
     {{if hasLabel $service "frontend.auth.basic"}}
       basicAuth = {{getLabelValue $service "frontend.auth.basic" ""}}
     {{end}}
 
-    {{if hasLabel $service "frontend.entryPoints"}}
-      entryPoints = {{getLabelValue $service "frontend.entryPoints" ""}}
+    {{if hasEntryPoints $service}}
+    entryPoints = [{{range getEntryPoints $service}}
+    "{{.}}",
+    {{end}}]
     {{end}}
     
     [frontends."frontend-{{$frontend}}".headers]

--- a/types.go
+++ b/types.go
@@ -9,11 +9,9 @@ import (
 // it belongs too and the replicas/partitions
 type ServiceItemExtended struct {
 	sf.ServiceItem
-	HasHTTPEndpoint bool
-	IsHealthy       bool
-	Application     sf.ApplicationItem
-	Partitions      []PartitionItemExtended
-	Labels          map[string]string
+	Application sf.ApplicationItem
+	Partitions  []PartitionItemExtended
+	Labels      map[string]string
 }
 
 // PartitionItemExtended provides a flattened view

--- a/types.go
+++ b/types.go
@@ -30,8 +30,9 @@ type sfClient interface {
 	GetPartitions(appName, serviceName string) (*sf.PartitionItemsPage, error)
 	GetReplicas(appName, serviceName, partitionName string) (*sf.ReplicaItemsPage, error)
 	GetInstances(appName, serviceName, partitionName string) (*sf.InstanceItemsPage, error)
-	GetServiceExtension(appType, applicationVersion, serviceTypeName, extensionKey string, response interface{}) error
+	GetServiceExtensionMap(service *sf.ServiceItem, app *sf.ApplicationItem, extensionKey string) (map[string]string, error)
 	GetServiceLabels(service *sf.ServiceItem, app *sf.ApplicationItem, prefix string) (map[string]string, error)
+	GetProperties(name string) (bool, map[string]string, error)
 }
 
 // replicaInstance interface provides a unified interface


### PR DESCRIPTION
Hi, 

This is WIP at the moment but I wanted to check in before I go much further - in case this is the wrong direction. 

- I've started to add a few additional labels using explicit methods, as discussed in #3. Adding `PassTLSCert`, `FrameDeny` and `RequestHeaders`
- I've tried to bring existing SF labels in line with those in `providers/labels` so `isExposed` -> `Enabled`
- To make sure they behave as expected I've created a new test
- I've renamed existing label functions to ensure those that return a `func` are have `func` in the name and those that don't don't

Let me know if this all makes sense and I'll continue to add the remaining labels from the docker provider implementation in v1.5