### PR TITLE
fix: backend name for stateful service.

### DIFF
--- a/servicefabric_tmpl.go
+++ b/servicefabric_tmpl.go
@@ -126,13 +126,15 @@ const tmpl = `
       {{range $partition := $service.Partitions}}
         {{$partitionId := $partition.PartitionInformation.ID}}
 
-        {{if hasLabel $service "frontend.rule"}}
-          [frontends."{{$service.Name}}/{{$partitionId}}"]
-          backend = "{{getBackendName $service $partition}}"
-          [frontends."{{$service.Name}}/{{$partitionId}}".routes.default]
-          rule = "{{getLabelValue $service "frontend.rule.partition.$partitionId" ""}}"
+        {{ $rule := getLabelValue $service (print "frontend.rule.partition." $partitionId) "" }}
+        {{if $rule }}
+        [frontends."{{ $service.Name }}/{{ $partitionId }}"]
+          backend = "{{ getBackendName $service $partition }}"
 
-      {{end}}
+          [frontends."{{ $service.Name }}/{{ $partitionId }}".routes.default]
+            rule = "{{ $rule }}"
+        {{end}}
+
     {{end}}
   {{end}}
 {{end}}

--- a/servicefabric_tmpl.go
+++ b/servicefabric_tmpl.go
@@ -58,7 +58,7 @@ const tmpl = `
         {{range $replica := $partition.Replicas}}
           {{if isPrimary $replica}}
 
-            {{$backendName := getBackendName $service.Name $partition}}
+            {{$backendName := getBackendName $service $partition}}
             [backends."{{$backendName}}".servers."{{$replica.ID}}"]
             url = "{{getDefaultEndpoint $replica}}"
             weight = 1
@@ -128,9 +128,9 @@ const tmpl = `
 
         {{if hasLabel $service "frontend.rule"}}
           [frontends."{{$service.Name}}/{{$partitionId}}"]
-          backend = "{{getBackendName $service.Name $partition}}"
+          backend = "{{getBackendName $service $partition}}"
           [frontends."{{$service.Name}}/{{$partitionId}}".routes.default]
-          rule = {{getLabelValue $service "frontend.rule.partition.$partitionId" ""}}
+          rule = "{{getLabelValue $service "frontend.rule.partition.$partitionId" ""}}"
 
       {{end}}
     {{end}}


### PR DESCRIPTION
fix: backend name for stateful service.

Closes #22

```shell
{"Interval":30000000000},"RespondingTimeouts":null,"ForwardingTimeouts":null,"Web":null,"Docker":null,"File":null,"Marathon":null,"Consul":null,"ConsulCatalog":null,"Etcd":null,"Zookeeper":null,"Boltdb":null,"Kubernetes":null,"Mesos":null,"Eureka":null,"ECS":null,"Rancher":null,"DynamoDB":null,"ServiceFabric":{"Watch":false,"Filename":"","Constraints":null,"Trace":false,"DebugLogGeneratedTemplate":false,"ClusterManagementURL":"https://servicefabric-prod02.klwines.com:19080","APIVersion":"3.0","RefreshSeconds":0,"TLS":{"CA":"","CAOptional":false,"Cert":"certs/servicefabric.crt","Key":"certs/servicefabric.key","InsecureSkipVerify":true}},"Rest":null,"API":{"EntryPoint":"traefik","Dashboard":true,"Debug":true,"CurrentConfigurations":null,"Statistics":null},"Metrics":null,"Ping":null}"
time="2018-04-13T01:42:15Z" level=info msg="Preparing server traefik &{Network: Address::8080 TLS:<nil> Redirect:<nil> Auth:<nil> WhitelistSourceRange:[] Compress:false ProxyProtocol:<nil> ForwardedHeaders:0xc042601080} with readTimeout=0s writeTimeout=0s idleTimeout=3m0s"
time="2018-04-13T01:42:15Z" level=info msg="Preparing server http &{Network: Address::80 TLS:<nil> Redirect:<nil> Auth:<nil> WhitelistSourceRange:[] Compress:false ProxyProtocol:<nil> ForwardedHeaders:0xc0426010a0} with readTimeout=0s writeTimeout=0s idleTimeout=3m0s"
time="2018-04-13T01:42:15Z" level=info msg="Starting server on :8080"
time="2018-04-13T01:42:15Z" level=info msg="Starting server on :80"
time="2018-04-13T01:42:15Z" level=info msg="Starting provider *servicefabric.Provider {"Watch":false,"Filename":"","Constraints":null,"Trace":false,"DebugLogGeneratedTemplate":false,"ClusterManagementURL":"https://servicefabric-prod02.xxxxxxxx.com:19080","APIVersion":"3.0","RefreshSeconds":0,"TLS":{"CA":"","CAOptional":false,"Cert":"certs/servicefabric.crt","Key":"certs/servicefabric.key","InsecureSkipVerify":true}}"
time="2018-04-13T01:42:25Z" level=info msg="Checking service fabric config"
time="2018-04-13T01:42:25Z" level=error msg="Provider connection error: template: :59:53: executing "" at <$service.Name>: wrong type for value; expected servicefabric.ServiceItemExtended; got string; retrying in 502.60397ms"
time="2018-04-13T01:42:36Z" level=info msg="Checking service fabric config"
time="2018-04-13T01:42:36Z" level=error msg="Provider connection error: template: :59:53: executing "" at <$service.Name>: wrong type for value; expected servicefabric.ServiceItemExtended; got string; retrying in 1.08877612s"
time="2018-04-13T01:42:47Z" level=info msg="Checking service fabric config"
time="2018-04-13T01:42:47Z" level=error msg="Provider connection error: template: :59:53: executing "" at <$service.Name>: wrong type for value; expected servicefabric.ServiceItemExtended; got string; retrying in 308.484166ms"
time="2018-04-13T01:42:58Z" level=info msg="Checking service fabric config"
time="2018-04-13T01:42:58Z" level=error msg="Provider connection error: template: :59:53: executing "" at <$service.Name>: wrong type for value; expected servicefabric.ServiceItemExtended; got string; retrying in 503.160157ms" 
```