### PR TITLE
Change `dep` to use `--vendor-only`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ test: clean
 	go test -v -cover ./...
 
 dependencies:
-	dep ensure -v
+	dep ensure -v --vendor-only
 
 clean:
 	rm -f cover.out


### PR DESCRIPTION
This will prevent `dep` from automatically adding missing dependencies to the the lock file. Ensuring the build will fail if committers haven't used `dep ensure -add` to include new dependencies. 