### PR TITLE
add support for specifying the name of the endpoint

### DIFF
--- a/servicefabric_test.go
+++ b/servicefabric_test.go
@@ -333,6 +333,52 @@ func TestGetReplicaDefaultEndpoint(t *testing.T) {
 	}
 }
 
+func TestGetReplicaNamedEndpoint(t *testing.T) {
+	testCases := []struct {
+		desc             string
+		replicaData      *sf.ReplicaItemBase
+		expectedEndpoint string
+		errorExpected    bool
+	}{
+		{
+			desc: "valid named endpoint",
+			replicaData: &sf.ReplicaItemBase{
+				Address: `{"Endpoints":{"OtherEndpoint":"http://localhost:8081","DefaultEndpoint":"http://localhost:8082"}}`,
+			},
+			expectedEndpoint: "http://localhost:8082",
+		},
+		{
+			desc: "invalid named endpoint",
+			replicaData: &sf.ReplicaItemBase{
+				Address: `{"Endpoints":{"OtherEndpoint":"http://localhost:8081"}}`,
+			},
+			errorExpected: true,
+		},
+	}
+
+	for _, test := range testCases {
+		test := test
+		t.Run(test.desc, func(t *testing.T) {
+			t.Parallel()
+
+			namedEndpoint, err := getReplicaNamedEndpoint(test.replicaData, "DefaultEndpoint")
+			if test.errorExpected {
+				if err == nil {
+					t.Fatal("Expected an error, got no error")
+				}
+			} else {
+				if err != nil {
+					t.Fatalf("Expected no error, got %v", err)
+				}
+
+				if namedEndpoint != test.expectedEndpoint {
+					t.Errorf("Got %s, want %s", namedEndpoint, test.expectedEndpoint)
+				}
+			}
+		})
+	}
+}
+
 func TestGetClusterServices(t *testing.T) {
 	client := &clientMock{
 		applications: apps,

--- a/servicefabric_tmpl.go
+++ b/servicefabric_tmpl.go
@@ -7,16 +7,14 @@ const tmpl = `
   {{range $service := $aggServices }}
   {{range $partition := $service.Partitions }}
   {{range $instance := $partition.Instances }}
-    {{ $endpointName := getLabelValue $service "traefik.servicefabric.endpointname" "" }}
-    {{if $endpointName }}
-      [backends."{{ $aggName }}".servers."{{ $service.ID }}-{{ $instance.ID }}"]
+    [backends."{{ $aggName }}".servers."{{ $service.ID }}-{{ $instance.ID }}"]
+      weight = {{ getGroupedWeight $service }}
+      {{ $endpointName := getLabelValue $service "traefik.servicefabric.endpointname" "" }}
+      {{if $endpointName }}
         url = "{{ getNamedEndpoint $instance $endpointName }}"
-        weight = {{ getGroupedWeight $service }}
-    {{else}}
-      [backends."{{ $aggName }}".servers."{{ $service.ID }}-{{ $instance.ID }}"]
+      {{else}}
         url = "{{ getDefaultEndpoint $instance }}"
-        weight = {{ getGroupedWeight $service }}
-    {{end}}
+      {{end}}
   {{end}}
   {{end}}
   {{end}}
@@ -71,15 +69,13 @@ const tmpl = `
         {{end}}
 
         {{range $instance := $partition.Instances}}
-          {{ $endpointName := getLabelValue $service "traefik.servicefabric.endpointname" "" }}
-          {{if $endpointName }}
-            [backends."{{ $service.Name }}".servers."{{ $instance.ID }}"]
+          [backends."{{ $service.Name }}".servers."{{ $instance.ID }}"]
+            weight = {{ getWeight $service }}
+            {{ $endpointName := getLabelValue $service "traefik.servicefabric.endpointname" "" }}
+            {{if $endpointName }}
               url = "{{ getNamedEndpoint $instance $endpointName }}"
-              weight = {{ getWeight $service }}
-          {{else}}
-            [backends."{{ $service.Name }}".servers."{{ $instance.ID }}"]
+            {{else}}
               url = "{{ getDefaultEndpoint $instance }}"
-              weight = {{ getWeight $service }}
           {{end}}
         {{end}}
 
@@ -88,16 +84,14 @@ const tmpl = `
         {{range $replica := $partition.Replicas}}
           {{if isPrimary $replica}}
             {{ $backendName := getBackendName $service $partition }}
-            {{ $endpointName := getLabelValue $service "traefik.servicefabric.endpointname" "" }}
-            {{if $endpointName }}
-              [backends."{{ $backendName }}".servers."{{ $replica.ID }}"]
+            [backends."{{ $backendName }}".servers."{{ $replica.ID }}"]
+              weight = 1
+              {{ $endpointName := getLabelValue $service "traefik.servicefabric.endpointname" "" }}
+              {{if $endpointName }}
                 url = "{{ getNamedEndpoint $replica $endpointName }}"
-                weight = 1
-            {{else}}
-              [backends."{{ $backendName }}".servers."{{ $replica.ID }}"]
+              {{else}}
                 url = "{{ getDefaultEndpoint $replica }}"
-                weight = 1
-            {{end}}
+              {{end}}
 
               [backends."{{$backendName}}".LoadBalancer]
                 method = "drr"

--- a/servicefabric_tmpl.go
+++ b/servicefabric_tmpl.go
@@ -7,7 +7,7 @@ const tmpl = `
   {{range $service := $aggServices }}
   {{range $partition := $service.Partitions }}
   {{range $instance := $partition.Instances }}
-    {{ $endpointName := getLabelValue $service "traefik.portName" "" }}
+    {{ $endpointName := getLabelValue $service "traefik.servicefabric.endpointname" "" }}
     {{if $endpointName }}
       [backends."{{ $aggName }}".servers."{{ $service.ID }}-{{ $instance.ID }}"]
         url = "{{ getNamedEndpoint $instance $endpointName }}"
@@ -71,7 +71,7 @@ const tmpl = `
         {{end}}
 
         {{range $instance := $partition.Instances}}
-          {{ $endpointName := getLabelValue $service "traefik.portName" "" }}
+          {{ $endpointName := getLabelValue $service "traefik.servicefabric.endpointname" "" }}
           {{if $endpointName }}
             [backends."{{ $service.Name }}".servers."{{ $instance.ID }}"]
               url = "{{ getNamedEndpoint $instance $endpointName }}"
@@ -88,7 +88,7 @@ const tmpl = `
         {{range $replica := $partition.Replicas}}
           {{if isPrimary $replica}}
             {{ $backendName := getBackendName $service $partition }}
-            {{ $endpointName := getLabelValue $service "traefik.portName" "" }}
+            {{ $endpointName := getLabelValue $service "traefik.servicefabric.endpointname" "" }}
             {{if $endpointName }}
               [backends."{{ $backendName }}".servers."{{ $replica.ID }}"]
                 url = "{{ getNamedEndpoint $replica $endpointName }}"


### PR DESCRIPTION
You add a "traefik.portName" label to your Service Fabric manifest and specify the name of the endpoint that you want to serve web traffic through.

Example:

```xml
<?xml version="1.0" encoding="utf-8"?>
<ServiceManifest Name="WebPkg" Version="1.0.0" xmlns="http://schemas.microsoft.com/2011/01/fabric" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
  <ServiceTypes>
    <!-- This is the name of your ServiceType.
         The UseImplicitHost attribute indicates this is a guest service. -->
    <StatelessServiceType ServiceTypeName="WebType" UseImplicitHost="true">
      <Extensions>
        <Extension Name="Traefik">
          <Labels xmlns="http://schemas.microsoft.com/2015/03/fabact-no-schema">
            <Label Key="traefik.servicefabric.endpointname">DefaultEndpoint</Label>
            <Label Key="traefik.backend.healthcheck.path">/</Label>
            <Label Key="traefik.backend.healthcheck.port">5050</Label>
            <Label Key="traefik.backend.healthcheck.interval">5s</Label>
            <Label Key="traefik.frontend.priority">10</Label>
            <Label Key="traefik.enable">true</Label>
          </Labels>
        </Extension>
      </Extensions>
    </StatelessServiceType>
  </ServiceTypes>

  <!-- Code package is your service executable. -->
  <CodePackage Name="Code" Version="1.0.0">
      <EntryPoint>
      <ExeHost>
        <Program>Web.exe</Program>
        <WorkingFolder>CodeBase</WorkingFolder>
        <!-- Uncomment to log console output (both stdout and stderr) to one of the
             service's working directories. -->
        <ConsoleRedirection FileRetentionCount="5" FileMaxSizeInKb="2048"/>
      </ExeHost>
    </EntryPoint>
  </CodePackage>
  <ConfigPackage Name="Config" Version="1.0.0" />

  <Resources>
    <Endpoints>
      <!-- This endpoint is used by the communication listener to obtain the port on which to
           listen. Please note that if your service is partitioned, this port is shared with
           replicas of different partitions that are placed in your code. -->
      <Endpoint Name="DefaultEndpoint" UriScheme="http" Port="8000" Protocol="http" Type="Input" />
      <Endpoint Name="HealthCheckEndpoint" UriScheme="http" Port="5050" Protocol="http" Type="Input" />
    </Endpoints>
  </Resources>
</ServiceManifest>
```

