### PR TITLE
added custom error page support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,7 @@
 .PHONY: default test dependencies clean build checks
 
+GOFILES = $(shell git ls-files '*.go' | grep -v '^vendor/')
+
 default: clean checks test build
 
 test: clean
@@ -16,3 +18,6 @@ build:
 
 checks:
 	golangci-lint run
+
+fmt:
+	gofmt -s -l -w $(GOFILES)

--- a/servicefabric_config.go
+++ b/servicefabric_config.go
@@ -48,7 +48,7 @@ func (p *Provider) buildConfiguration(services []ServiceItemExtended) (*types.Co
 		"getWhiteList":      getWhiteList,
 		"getHeaders":        getHeaders,
 		"getRedirect":       getRedirect,
-		"getErrorPages":	 getErrorPages,
+		"getErrorPages":     getErrorPages,
 
 		// SF Service Grouping
 		"getGroupedServices": getFuncServicesGroupedByLabel(traefikSFGroupName),

--- a/servicefabric_config.go
+++ b/servicefabric_config.go
@@ -48,6 +48,7 @@ func (p *Provider) buildConfiguration(services []ServiceItemExtended) (*types.Co
 		"getWhiteList":      getWhiteList,
 		"getHeaders":        getHeaders,
 		"getRedirect":       getRedirect,
+		"getErrorPages":	 getErrorPages,
 
 		// SF Service Grouping
 		"getGroupedServices": getFuncServicesGroupedByLabel(traefikSFGroupName),
@@ -171,4 +172,8 @@ func getCircuitBreaker(service ServiceItemExtended) *types.CircuitBreaker {
 
 func getLoadBalancer(service ServiceItemExtended) *types.LoadBalancer {
 	return label.GetLoadBalancer(service.Labels)
+}
+
+func getErrorPages(service ServiceItemExtended) map[string]*types.ErrorPage {
+	return label.GetErrorPages(service.Labels)
 }

--- a/servicefabric_config_test.go
+++ b/servicefabric_config_test.go
@@ -308,6 +308,23 @@ func TestBuildConfigurationFrontendLabelConfig(t *testing.T) {
 			},
 		},
 		{
+			desc: "Has error pages set",
+			labels: map[string]string{
+				label.TraefikEnable:                                                                "true",
+				label.Prefix + label.BaseFrontendErrorPage + "foo." + label.SuffixErrorPageStatus:  "401-404,503",
+				label.Prefix + label.BaseFrontendErrorPage + "foo." + label.SuffixErrorPageBackend: "fabric:/TestApplication/TestService",
+				label.Prefix + label.BaseFrontendErrorPage + "foo." + label.SuffixErrorPageQuery:   "/404.html",
+			},
+			validate: func(t *testing.T, b *types.Backend) {
+				expected := &types.ErrorPage{
+					Status:   []string{"401-404", "503"},
+					Backend:  "fabric:/TestApplication/TestService",
+					Query: 	  "/404.html",
+				}
+				assert.Equal(t, expected, b.HealthCheck)
+			},
+		},
+		{
 			desc: "Has basicAuth set",
 			labels: map[string]string{
 				label.TraefikEnable:            "true",
@@ -619,24 +636,7 @@ func TestBuildConfigurationBackendLabelConfig(t *testing.T) {
 				}
 				assert.Equal(t, expected, b.HealthCheck)
 			},
-		},
-		{
-			desc: "Has error pages set",
-			labels: map[string]string{
-				label.TraefikEnable:                        "true",
-				label.TraefikFrontendErrorsNetworksStatus:  "401-404,503",
-				label.TraefikFrontendErrorsNetworksBackend: "fabric:/TestApplication/TestService",
-				label.TraefikFrontendErrorsNetworksQuery:   "/404.html",
-			},
-			validate: func(t *testing.T, b *types.Backend) {
-				expected := &types.ErrorPage{
-					Status:   []string{"401-404", "503"},
-					Backend:  "fabric:/TestApplication/TestService",
-					Query: 	  "/404.html",
-				}
-				assert.Equal(t, expected, b.HealthCheck)
-			},
-		},
+		},		
 		{
 			desc: "Has circuit breaker set",
 			labels: map[string]string{

--- a/servicefabric_config_test.go
+++ b/servicefabric_config_test.go
@@ -621,6 +621,23 @@ func TestBuildConfigurationBackendLabelConfig(t *testing.T) {
 			},
 		},
 		{
+			desc: "Has error pages set",
+			labels: map[string]string{
+				label.TraefikEnable:                     	"true",
+				label.TraefikFrontendErrorsNetworksStatus: 	"401-404,503",
+				label.TraefikFrontendErrorsNetworksBackend: "fabric:/TestApplication/TestService",
+				label.TraefikFrontendErrorsNetworksQuery: 	"/404.html",
+			},
+			validate: func(t *testing.T, b *types.Backend) {
+				expected := &types.ErrorPage{
+					Status:   ["401-404","503"],
+					Backend:  "fabric:/TestApplication/TestService",
+					Query: 	  "/404.html",
+				}
+				assert.Equal(t, expected, b.HealthCheck)
+			},
+		},
+		{
 			desc: "Has circuit breaker set",
 			labels: map[string]string{
 				label.TraefikEnable:                          "true",

--- a/servicefabric_config_test.go
+++ b/servicefabric_config_test.go
@@ -310,16 +310,16 @@ func TestBuildConfigurationFrontendLabelConfig(t *testing.T) {
 		{
 			desc: "Has error pages set",
 			labels: map[string]string{
-				label.TraefikEnable:                                                                "true",
+				label.TraefikEnable: "true",
 				label.Prefix + label.BaseFrontendErrorPage + "foo." + label.SuffixErrorPageStatus:  "401-404,503",
 				label.Prefix + label.BaseFrontendErrorPage + "foo." + label.SuffixErrorPageBackend: "fabric:/TestApplication/TestService",
 				label.Prefix + label.BaseFrontendErrorPage + "foo." + label.SuffixErrorPageQuery:   "/404.html",
 			},
 			validate: func(t *testing.T, b *types.Frontend) {
 				expected := &types.ErrorPage{
-					Status:   []string{"401-404", "503"},
-					Backend:  "fabric:/TestApplication/TestService",
-					Query: 	  "/404.html",
+					Status:  []string{"401-404", "503"},
+					Backend: "fabric:/TestApplication/TestService",
+					Query:   "/404.html",
 				}
 				assert.Equal(t, expected, b.Errors)
 			},

--- a/servicefabric_config_test.go
+++ b/servicefabric_config_test.go
@@ -321,7 +321,7 @@ func TestBuildConfigurationFrontendLabelConfig(t *testing.T) {
 					Backend:  "fabric:/TestApplication/TestService",
 					Query: 	  "/404.html",
 				}
-				assert.Equal(t, expected, b.HealthCheck)
+				assert.Equal(t, expected, b.ErrorPage)
 			},
 		},
 		{

--- a/servicefabric_config_test.go
+++ b/servicefabric_config_test.go
@@ -630,7 +630,7 @@ func TestBuildConfigurationBackendLabelConfig(t *testing.T) {
 			},
 			validate: func(t *testing.T, b *types.Backend) {
 				expected := &types.ErrorPage{
-					Status:   ["401-404","503"],
+					Status:   []string{"401-404", "503"},
 					Backend:  "fabric:/TestApplication/TestService",
 					Query: 	  "/404.html",
 				}

--- a/servicefabric_config_test.go
+++ b/servicefabric_config_test.go
@@ -315,7 +315,7 @@ func TestBuildConfigurationFrontendLabelConfig(t *testing.T) {
 				label.Prefix + label.BaseFrontendErrorPage + "foo." + label.SuffixErrorPageBackend: "fabric:/TestApplication/TestService",
 				label.Prefix + label.BaseFrontendErrorPage + "foo." + label.SuffixErrorPageQuery:   "/404.html",
 			},
-			validate: func(t *testing.T, b *types.Backend) {
+			validate: func(t *testing.T, b *types.Frontend) {
 				expected := &types.ErrorPage{
 					Status:   []string{"401-404", "503"},
 					Backend:  "fabric:/TestApplication/TestService",
@@ -636,7 +636,7 @@ func TestBuildConfigurationBackendLabelConfig(t *testing.T) {
 				}
 				assert.Equal(t, expected, b.HealthCheck)
 			},
-		},		
+		},
 		{
 			desc: "Has circuit breaker set",
 			labels: map[string]string{

--- a/servicefabric_config_test.go
+++ b/servicefabric_config_test.go
@@ -321,7 +321,7 @@ func TestBuildConfigurationFrontendLabelConfig(t *testing.T) {
 					Backend:  "fabric:/TestApplication/TestService",
 					Query: 	  "/404.html",
 				}
-				assert.Equal(t, expected, b.ErrorPage)
+				assert.Equal(t, expected, b.Errors)
 			},
 		},
 		{

--- a/servicefabric_config_test.go
+++ b/servicefabric_config_test.go
@@ -316,10 +316,12 @@ func TestBuildConfigurationFrontendLabelConfig(t *testing.T) {
 				label.Prefix + label.BaseFrontendErrorPage + "foo." + label.SuffixErrorPageQuery:   "/404.html",
 			},
 			validate: func(t *testing.T, b *types.Frontend) {
-				expected := &types.ErrorPage{
-					Status:  []string{"401-404", "503"},
-					Backend: "fabric:/TestApplication/TestService",
-					Query:   "/404.html",
+				expected := map[string]*types.ErrorPage{
+					"foo": {
+						Status:  []string{"401-404", "503"},
+						Backend: "fabric:/TestApplication/TestService",
+						Query:   "/404.html",
+					},
 				}
 				assert.Equal(t, expected, b.Errors)
 			},

--- a/servicefabric_config_test.go
+++ b/servicefabric_config_test.go
@@ -623,10 +623,10 @@ func TestBuildConfigurationBackendLabelConfig(t *testing.T) {
 		{
 			desc: "Has error pages set",
 			labels: map[string]string{
-				label.TraefikEnable:                     	"true",
-				label.TraefikFrontendErrorsNetworksStatus: 	"401-404,503",
+				label.TraefikEnable:                        "true",
+				label.TraefikFrontendErrorsNetworksStatus:  "401-404,503",
 				label.TraefikFrontendErrorsNetworksBackend: "fabric:/TestApplication/TestService",
-				label.TraefikFrontendErrorsNetworksQuery: 	"/404.html",
+				label.TraefikFrontendErrorsNetworksQuery:   "/404.html",
 			},
 			validate: func(t *testing.T, b *types.Backend) {
 				expected := &types.ErrorPage{

--- a/servicefabric_tmpl.go
+++ b/servicefabric_tmpl.go
@@ -162,6 +162,19 @@ const tmpl = `
           permanent = {{ $redirect.Permanent }}
         {{end}}
 
+        {{ $errorPages := getErrorPages $service }}
+        {{if $errorPages }}
+        [frontends."frontend-{{ $frontendName }}".errors]
+          {{range $pageName, $page := $errorPages }}
+          [frontends."frontend-{{ $frontendName }}".errors."{{ $pageName }}"]
+            status = [{{range $page.Status }}
+              "{{.}}",
+              {{end}}]
+            backend = "{{ $page.Backend }}"
+            query = "{{ $page.Query }}"
+          {{end}}
+        {{end}}
+
         {{ $headers := getHeaders $service }}
         {{if $headers }}
         [frontends."frontend-{{ $frontendName }}".headers]


### PR DESCRIPTION
Added custom error pages support based on the standard labels

Sorry if I'm missing something obvious, this is my first github pull request. I'm also not very familiar with go.

I've added this code in the vendor folder of the main traefik repository and I'm running the exe with success. 