### PR TITLE
Add SameSite, HTTPOnly, Secure cookie support (v1.7)

### DIFF
--- a/.golangci.toml
+++ b/.golangci.toml
@@ -29,17 +29,27 @@
     "dupl",
     "prealloc",
     "scopelint",
-    "stylecheck",
     "wsl",
+    "nlreturn",
     "godox",
     "gomnd",
+    "gomodguard",
+    "gochecknoglobals",
+    "goerr113",
+    "wrapcheck",
+    "testpackage",
+    "paralleltest",
+    "tparallel",
+    "exhaustivestruct",
   ]
 
 [issues]
   exclude-use-default = false
   max-per-linter = 0
   max-same-issues = 0
-  exclude = []
+  exclude = [
+    "ST1000: at least one file in a package should have a package comment",
+  ]
   [[issues.exclude-rules]]
     path = "servicefabric_test.go"
     text = "`(apps|services|partitions|instances|labels)` is a global variable"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,7 @@
 language: go
 
 go:
-  - 1.11.x
-  - 1.12.x
+  - 1.14.x
 
 sudo: false
 
@@ -17,7 +16,7 @@ before_install:
   - chmod +x $GOPATH/bin/dep
 
   # Install linters and misspell
-  - curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | bash -s -- -b $GOPATH/bin v1.22.2
+  - curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | bash -s -- -b $GOPATH/bin v1.34.1
   - golangci-lint --version
 
 install: make dependencies

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -84,24 +84,6 @@
   revision = "c33f32e268983f989290677351b871b65da75ba5"
 
 [[projects]]
-  branch = "v1.7"
-  digest = "1:be5fd3ee68c26b86b3b469ec695d31ee4d908cf207e787ebbdd3e98c118b25fe"
-  name = "github.com/traefik/traefik"
-  packages = [
-    "autogen/gentemplates",
-    "job",
-    "log",
-    "provider",
-    "provider/label",
-    "safe",
-    "tls",
-    "tls/generate",
-    "types",
-  ]
-  pruneopts = ""
-  revision = "57ae9a80d5ccba29c8f566a8be4c27512727d9ac"
-
-[[projects]]
   digest = "1:0deddd908b6b4b768cfc272c16ee61e7088a60f7fe2f06c547bd3d8e1f8b8e77"
   name = "github.com/davecgh/go-spew"
   packages = ["spew"]
@@ -224,6 +206,24 @@
   version = "v1.3.0"
 
 [[projects]]
+  branch = "v1.7"
+  digest = "1:5b9631e9bc1f6f659052c48a183ae9e17905e65b0846a977a344635b16dcc861"
+  name = "github.com/traefik/traefik"
+  packages = [
+    "autogen/gentemplates",
+    "job",
+    "log",
+    "provider",
+    "provider/label",
+    "safe",
+    "tls",
+    "tls/generate",
+    "types",
+  ]
+  pruneopts = ""
+  revision = "d1befe7b122c6f5e95d730936c0993ca456fd071"
+
+[[projects]]
   branch = "master"
   digest = "1:36ef1d8645934b1744cc7d8726e00d3dd9d8d84c18617bf7367a3a6d532f3370"
   name = "golang.org/x/crypto"
@@ -252,16 +252,16 @@
   input-imports = [
     "github.com/cenk/backoff",
     "github.com/containous/flaeg",
+    "github.com/jjcollinge/logrus-appinsights",
+    "github.com/jjcollinge/servicefabric",
+    "github.com/stretchr/testify/assert",
+    "github.com/stretchr/testify/require",
     "github.com/traefik/traefik/job",
     "github.com/traefik/traefik/log",
     "github.com/traefik/traefik/provider",
     "github.com/traefik/traefik/provider/label",
     "github.com/traefik/traefik/safe",
     "github.com/traefik/traefik/types",
-    "github.com/jjcollinge/logrus-appinsights",
-    "github.com/jjcollinge/servicefabric",
-    "github.com/stretchr/testify/assert",
-    "github.com/stretchr/testify/require",
   ]
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/client_mock_test.go
+++ b/client_mock_test.go
@@ -49,7 +49,7 @@ func (c *clientMock) GetServiceLabels(service *sf.ServiceItem, app *sf.Applicati
 	return c.getServicelabelsResult, nil
 }
 
-// Note this is dumb mock the `exists`
+// Note this is dumb mock the `exists`.
 func (c *clientMock) GetProperties(name string) (bool, map[string]string, error) {
 	if c.expectedPropertyName == name {
 		return true, c.getPropertiesResult, nil

--- a/servicefabric.go
+++ b/servicefabric.go
@@ -28,7 +28,7 @@ const (
 	kindStateless = "Stateless"
 )
 
-// Provider holds for configuration for the provider
+// Provider holds for configuration for the provider.
 type Provider struct {
 	provider.BaseProvider `mapstructure:",squash"`
 	ClusterManagementURL  string           `description:"Service Fabric API endpoint"`
@@ -42,7 +42,7 @@ type Provider struct {
 	sfClient              sfClient
 }
 
-// Init the provider
+// Init the provider.
 func (p *Provider) Init(constraints types.Constraints) error {
 	err := p.BaseProvider.Init(constraints)
 	if err != nil {

--- a/servicefabric_config.go
+++ b/servicefabric_config.go
@@ -13,7 +13,7 @@ import (
 )
 
 func (p *Provider) buildConfiguration(services []ServiceItemExtended) (*types.Configuration, error) {
-	var sfFuncMap = template.FuncMap{
+	sfFuncMap := template.FuncMap{
 		// Services
 		"getServices":                getServices,
 		"hasLabel":                   hasService,

--- a/servicefabric_config_test.go
+++ b/servicefabric_config_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 // TestServicesPresentInConfig tests that the basic services provide by SF
-// are return in the configuration object
+// are return in the configuration object.
 func TestBuildConfigurationServicesPresentInConfig(t *testing.T) {
 	provider := Provider{}
 
@@ -242,7 +242,6 @@ func TestBuildConfigurationStateful(t *testing.T) {
 	}
 }
 
-// nolint: gocyclo
 func TestBuildConfigurationFrontendLabelConfig(t *testing.T) {
 	testCases := []struct {
 		desc     string
@@ -597,7 +596,6 @@ func TestBuildConfigurationFrontendLabelConfig(t *testing.T) {
 	}
 }
 
-// nolint: gocyclo
 func TestBuildConfigurationBackendLabelConfig(t *testing.T) {
 	testCases := []struct {
 		desc     string

--- a/servicefabric_labelfuncs.go
+++ b/servicefabric_labelfuncs.go
@@ -6,7 +6,7 @@ import (
 	"github.com/traefik/traefik/provider/label"
 )
 
-// SF Specific Traefik Labels
+// SF Specific Traefik Labels.
 const (
 	traefikSFGroupName                   = "traefik.servicefabric.groupname"
 	traefikSFGroupWeight                 = "traefik.servicefabric.groupweight"

--- a/servicefabric_tmpl.go
+++ b/servicefabric_tmpl.go
@@ -46,7 +46,7 @@ const tmpl = `
               secure = {{ $loadBalancer.Stickiness.Secure }}
               httpOnly = {{ $loadBalancer.Stickiness.HTTPOnly }}
               sameSite = "{{ $loadBalancer.Stickiness.SameSite }}"
-			{{end}}
+            {{end}}
         {{end}}
 
         {{ $maxConn := getMaxConn $service }}

--- a/servicefabric_tmpl.go
+++ b/servicefabric_tmpl.go
@@ -43,7 +43,10 @@ const tmpl = `
             {{if $loadBalancer.Stickiness }}
             [backends."{{ $backendName }}".loadBalancer.stickiness]
               cookieName = "{{ $loadBalancer.Stickiness.CookieName }}"
-            {{end}}
+              secure = {{ $loadBalancer.Stickiness.Secure }}
+              httpOnly = {{ $loadBalancer.Stickiness.HTTPOnly }}
+              sameSite = "{{ $loadBalancer.Stickiness.SameSite }}"
+			{{end}}
         {{end}}
 
         {{ $maxConn := getMaxConn $service }}

--- a/types.go
+++ b/types.go
@@ -6,7 +6,7 @@ import (
 
 // ServiceItemExtended provides a flattened view
 // of the service with details of the application
-// it belongs too and the replicas/partitions
+// it belongs too and the replicas/partitions.
 type ServiceItemExtended struct {
 	sf.ServiceItem
 	Application sf.ApplicationItem
@@ -15,7 +15,7 @@ type ServiceItemExtended struct {
 }
 
 // PartitionItemExtended provides a flattened view
-// of a services partitions
+// of a services partitions.
 type PartitionItemExtended struct {
 	sf.PartitionItem
 	Replicas  []sf.ReplicaItem
@@ -36,7 +36,7 @@ type sfClient interface {
 }
 
 // replicaInstance interface provides a unified interface
-// over replicas and instances
+// over replicas and instances.
 type replicaInstance interface {
 	GetReplicaData() (string, *sf.ReplicaItemBase)
 }


### PR DESCRIPTION
1. Update traefik dependency to latest v1.7 changes.
2. Update servicefabric provider template to include the [SameSite, HTTPOnly, Secure] labels under LoadBalancer.Stickiness.

Related to https://github.com/traefik/traefik/pull/7667